### PR TITLE
Add Cursor Cloud specific development instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,27 @@ tests/                   regression tests and unit tests for the library's core 
 3. Add or update targeted tests (`tests/test_*.py`) alongside code changes.
 4. Run the scoped pytest command (`uv run test -m ...`) before submitting.
 5. Keep documentation edits minimal and aligned with the per-module format.
+
+## Cursor Cloud specific instructions
+
+### Environment
+- Python 3.10 is required (`requires-python = "==3.10.*"`). The update script installs it via `uv python install 3.10` and then runs `uv sync`.
+- All commands use `uv run` (e.g. `uv run pytest`, `uv run -m koopmanrl.<module>`). There is no separate venv activation step.
+- This is a pure Python scientific computing package with zero external service dependencies (no databases, Docker, web servers, etc.).
+
+### Lint
+- `uv run pre-commit run --all-files` runs ruff, ruff-format, vulture, isort, and general file checks.
+
+### Tests
+- `uv run pytest tests/test_rl.py -v` runs all 20 RL algorithm tests (5 algorithms × 4 environments). Takes ~8 minutes.
+- `uv run pytest tests/test_hparam_opt.py -v` runs Ray/Optuna hyperparameter optimization tests. These are slow (~10 min each) and use 16 CPU cores per trial.
+- To run a single test: `uv run pytest tests/test_rl.py -k "test_lqr[LinearSystem-v0]" -v`
+
+### Running algorithms
+- Each algorithm is a standalone module: `uv run -m koopmanrl.<module> --env_id <EnvName> --total_timesteps <N>`.
+- Use `--help` on any module for its full argument list.
+- SKVI/SAKC write checkpoints to `./saved_models/` and TensorBoard logs to `./runs/`.
+
+### Gotchas
+- The `gym==0.23.1` dependency emits deprecation warnings about NumPy 2.0 and `env.seed()`. These are harmless and expected.
+- The `koopmanrl_utils/` directory is a separate utility package for post-processing/visualization; it is not tested by the main test suite.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with environment setup context, lint/test commands, algorithm run instructions, and known gotchas for future cloud agents.

### What's included
- Python 3.10 requirement note and `uv` usage patterns
- Lint command (`uv run pre-commit run --all-files`)
- Test commands with timing expectations
- Algorithm execution patterns
- Known harmless warnings from `gym==0.23.1`

### Verification
All 20 RL algorithm tests pass (5 algorithms × 4 environments):

[test_results.log](https://cursor.com/agents/bc-850899dc-3c34-4e74-97f9-77331d8a4cd7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results.log)

Hello-world LQR run:

[lqr_hello_world.log](https://cursor.com/agents/bc-850899dc-3c34-4e74-97f9-77331d8a4cd7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flqr_hello_world.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-850899dc-3c34-4e74-97f9-77331d8a4cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-850899dc-3c34-4e74-97f9-77331d8a4cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

