### PR TITLE
GPU acceleration: device-aware environments, Koopman tensor, and RL algorithms

### DIFF
--- a/docs/superpowers/plans/2026-05-22-gpu-koopmanrl.md
+++ b/docs/superpowers/plans/2026-05-22-gpu-koopmanrl.md
@@ -1,0 +1,1067 @@
+# GPU-enabling KoopmanRL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run KoopmanRL's environments and RL algorithms (SKVI, SAKC, both Optuna wrappers, both CleanRL SAC variants) on an NVIDIA GPU, with batched device-native env dynamics and a single device-aware Koopman tensor, validated against the CPU baseline.
+
+**Architecture:** Keep the gym single-env numpy API untouched as the CPU/parity reference. Add batched, device-native `f_batch`/`reset_batch` to each env (substepped torch RK4 for FluidFlow/Lorenz, torch Euler–Maruyama for DoubleWell). Consolidate the triplicated `KoopmanTensor` into one device-aware module (`koopman_tensor/torch_tensor.py`) with the numpy round-trips and Python loops removed. Wire `--cuda`/`--fp32` through the algorithms (currently parsed but ignored). LQR stays on CPU.
+
+**Tech Stack:** Python 3.10, uv, PyTorch 2.9.1+cu128 (Blackwell sm_120), Gymnasium 1.0, pytest. Run everything via `uv run`.
+
+**Spec:** `docs/superpowers/specs/2026-05-22-gpu-koopmanrl-design.md`
+
+**Conventions for every task:** run tests with `uv run pytest ...`; commit on branch `gpu-acceleration`; end commit messages with the `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer. CPU baseline to preserve: `uv run pytest tests/test_environments.py tests/test_rl.py` = 28 passed.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `koopmanrl/utils.py` | Add `resolve_device`/`resolve_dtype` | Modify |
+| `koopmanrl/koopman_tensor/observables/torch_observables.py` | Device-aware monomials | Modify |
+| `koopmanrl/koopman_observables.py` | Re-export canonical observables | Modify |
+| `koopmanrl/koopman_tensor/torch_tensor.py` | Canonical device-aware `KoopmanTensor` + `generate_koopman_tensor` (incl. batched rollout) | Modify |
+| `koopmanrl/environments/linear_system.py` | `f_batch`/`reset_batch`, device-aware cost | Modify |
+| `koopmanrl/environments/fluid_flow.py` | Substepped RK4 `f_batch`/`reset_batch`, device cost | Modify |
+| `koopmanrl/environments/lorenz.py` | Substepped RK4 `f_batch`/`reset_batch`, device cost | Modify |
+| `koopmanrl/environments/double_well.py` | Euler–Maruyama `f_batch`/`reset_batch`, device cost | Modify |
+| `koopmanrl/soft_koopman_value_iteration.py` | Import canonical tensor; device; vectorize action loop | Modify |
+| `koopmanrl/soft_actor_koopman_critic.py` | Import canonical tensor; device | Modify |
+| `koopmanrl/sac_continuous_action.py` | Device resolution | Modify |
+| `koopmanrl/value_based_sac_continuous_action.py` | Device resolution | Modify |
+| `koopmanrl/opt_wrappers.py` | Device/dtype params | Modify |
+| `tests/test_gpu_parity.py` | CPU/GPU parity + integrator accuracy tests | Create |
+| `tests/test_rl.py` | `--cuda` smoke runs | Modify |
+| `koopmanrl/environments/AGENTS.md` | Note CPU + batched-GPU path | Modify |
+
+---
+
+## Task 1: Device & dtype helpers
+
+**Files:**
+- Modify: `koopmanrl/utils.py`
+- Test: `tests/test_device_utils.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_device_utils.py
+import torch
+from koopmanrl.utils import resolve_device, resolve_dtype
+
+
+def test_resolve_device_cpu_when_cuda_false():
+    assert resolve_device(False) == torch.device("cpu")
+
+
+def test_resolve_device_cuda_when_requested_and_available():
+    expected = "cuda" if torch.cuda.is_available() else "cpu"
+    assert resolve_device(True).type == expected
+
+
+def test_resolve_dtype():
+    assert resolve_dtype(False) == torch.float64
+    assert resolve_dtype(True) == torch.float32
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_device_utils.py -v`
+Expected: FAIL with `ImportError: cannot import name 'resolve_device'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `koopmanrl/utils.py` (add `import torch` at top of file):
+
+```python
+import torch
+
+
+def resolve_device(cuda: bool) -> torch.device:
+    """Return the CUDA device when requested and available, else CPU."""
+    return torch.device("cuda" if (cuda and torch.cuda.is_available()) else "cpu")
+
+
+def resolve_dtype(fp32: bool) -> torch.dtype:
+    """FP64 by default; FP32 when opted in (faster on consumer Blackwell)."""
+    return torch.float32 if fp32 else torch.float64
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_device_utils.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add koopmanrl/utils.py tests/test_device_utils.py
+git commit -m "feat: add resolve_device/resolve_dtype helpers"
+```
+
+---
+
+## Task 2: Device-aware observables (monomials)
+
+The hot path is `monomials.__call__`. It currently allocates `torch.ones([n, m])` on the default (CPU) device and uses a CPU powers matrix `c`, so it breaks when `x` is on CUDA. `diff`/`ddiff` are only used for the unused generator path and additionally call `.copy()` (a numpy-ism) on a torch tensor — fix them too for device-correctness and to remove the latent bug.
+
+**Files:**
+- Modify: `koopmanrl/koopman_tensor/observables/torch_observables.py`
+- Test: `tests/test_gpu_parity.py` (create with the monomials test; later tasks extend it)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_gpu_parity.py
+import pytest
+import torch
+
+from koopmanrl.koopman_tensor.observables.torch_observables import monomials
+
+CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ATOL = 1e-9
+
+
+@CUDA
+def test_monomials_cpu_gpu_parity():
+    phi = monomials(3)
+    x_cpu = torch.randn(3, 64, dtype=torch.float64)
+    x_gpu = x_cpu.cuda()
+    y_cpu = phi(x_cpu)
+    y_gpu = phi(x_gpu)
+    assert y_gpu.is_cuda
+    assert torch.allclose(y_cpu, y_gpu.cpu(), atol=ATOL)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_gpu_parity.py -v`
+Expected: FAIL (RuntimeError about tensors on different devices, or a CPU-resident result).
+
+- [ ] **Step 3: Implement**
+
+In `koopmanrl/koopman_tensor/observables/torch_observables.py`, edit `monomials.__call__` so allocations follow `x`:
+
+```python
+    def __call__(self, x):
+        [d, m] = x.shape
+        c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)
+        n = c.shape[1]
+        y = torch.ones([n, m], device=x.device, dtype=x.dtype)
+        for i in range(n):
+            for j in range(d):
+                y[i] *= torch.pow(x[j], c[j, i])
+        return y
+```
+
+Edit `diff` and `ddiff` the same way — allocate `y = torch.zeros([...], device=x.device, dtype=x.dtype)`, set `c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)`, and replace `e = c[:, i].copy()` with `e = c[:, i].clone()` (both occurrences). Leave `allMonomialPowers` as-is (small CPU build, `.to(...)` moves it).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_gpu_parity.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the CPU env tests to confirm no regression**
+
+Run: `uv run pytest tests/test_environments.py -v`
+Expected: 8 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add koopmanrl/koopman_tensor/observables/torch_observables.py tests/test_gpu_parity.py
+git commit -m "feat: make monomials observables device-aware"
+```
+
+---
+
+## Task 3: Canonical device-aware KoopmanTensor
+
+Make `koopman_tensor/torch_tensor.py` the single device-aware implementation: remove the `self.M.numpy()` + per-row Fortran-order reshape, vectorize the `kron` loop, and make `ridgeRegression` device-aware.
+
+**Files:**
+- Modify: `koopmanrl/koopman_tensor/torch_tensor.py`
+- Test: `tests/test_gpu_parity.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_gpu_parity.py`:
+
+```python
+from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor
+
+
+def _make_tensor(device):
+    torch.manual_seed(0)
+    N, state_dim, action_dim = 500, 3, 1
+    X = torch.randn(state_dim, N, dtype=torch.float64, device=device)
+    Y = X + 0.01 * torch.randn(state_dim, N, dtype=torch.float64, device=device)
+    U = torch.randn(action_dim, N, dtype=torch.float64, device=device)
+    return KoopmanTensor(X, Y, U, phi=monomials(2), psi=monomials(2), regressor=Regressor.OLS)
+
+
+@CUDA
+def test_koopman_tensor_cpu_gpu_parity():
+    kt_cpu = _make_tensor(torch.device("cpu"))
+    kt_gpu = _make_tensor(torch.device("cuda"))
+    assert kt_gpu.K.is_cuda and kt_gpu.B.is_cuda
+    assert torch.allclose(kt_cpu.K, kt_gpu.K.cpu(), atol=1e-6)
+    assert torch.allclose(kt_cpu.B, kt_gpu.B.cpu(), atol=1e-6)
+    # phi_f / f parity on a small sample
+    x = torch.randn(3, 16, dtype=torch.float64)
+    u = torch.randn(1, 16, dtype=torch.float64)
+    f_cpu = kt_cpu.f(x, u)
+    f_gpu = kt_gpu.f(x.cuda(), u.cuda())
+    assert torch.allclose(f_cpu, f_gpu.cpu(), atol=1e-6)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_gpu_parity.py::test_koopman_tensor_cpu_gpu_parity -v`
+Expected: FAIL (the current code calls `self.M.numpy()` on a CUDA tensor → `TypeError: can't convert cuda ... to numpy`).
+
+- [ ] **Step 3: Implement — vectorize kron**
+
+In `KoopmanTensor.__init__`, replace the kron loop:
+
+```python
+        # Build matrix of kronecker products between u_i and x_i for all 0 <= i <= N
+        # torch.kron(Psi_U[:,i], Phi_X[:,i])[a*phi_dim + b] = Psi_U[a,i] * Phi_X[b,i]
+        self.kron_matrix = torch.einsum("an,bn->abn", self.Psi_U, self.Phi_X).reshape(
+            self.psi_dim * self.phi_dim, self.N
+        )
+```
+
+- [ ] **Step 4: Implement — pure-torch K reshape**
+
+Replace the numpy reshape block:
+
+```python
+        # reshape M into tensor K without leaving the device.
+        # Original used a per-row Fortran-order reshape into (phi_dim, psi_dim);
+        # that equals the C-order reshape into (psi_dim, phi_dim) transposed.
+        self.M = self.M.contiguous()
+        self.K = self.M.reshape(self.phi_dim, self.psi_dim, self.phi_dim).transpose(-1, -2).contiguous()
+```
+
+(Delete the `self.K = np.empty(...)`, `self.M = self.M.numpy()`, the `for i in range(self.phi_dim)` loop, and the two trailing `torch.tensor(...)` casts.)
+
+- [ ] **Step 5: Implement — device-aware ridge**
+
+Make `ridgeRegression` device-aware:
+
+```python
+def ridgeRegression(X, y, lamb=0.05):
+    eye = torch.eye(X.shape[1], device=X.device, dtype=X.dtype)
+    return torch.linalg.inv(X.T @ X + lamb * eye) @ X.T @ y
+```
+
+- [ ] **Step 6: Run parity test**
+
+Run: `uv run pytest tests/test_gpu_parity.py::test_koopman_tensor_cpu_gpu_parity -v`
+Expected: PASS. If `torch.linalg.lstsq` raises on CUDA (full-rank `gels` driver), fall back: in `ols`, when `X.is_cuda`, use `torch.linalg.lstsq(X, Y, driver="gels").solution`; if still unstable, `return torch.linalg.pinv(X) @ Y`. Re-run until PASS.
+
+- [ ] **Step 7: Run generate_tensor + env tests (no regression)**
+
+Run: `uv run python -m koopmanrl.koopman_tensor.generate_tensor --env_id LinearSystem-v0 --num_paths 5 --num_steps_per_path 20`
+Expected: prints estimation-error stats, exit 0.
+Run: `uv run pytest tests/test_environments.py -v`
+Expected: 8 passed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add koopmanrl/koopman_tensor/torch_tensor.py tests/test_gpu_parity.py
+git commit -m "feat: device-aware KoopmanTensor (vectorized kron, torch-only K reshape)"
+```
+
+---
+
+## Task 4: LinearSystem batched dynamics + device-aware cost
+
+**Files:**
+- Modify: `koopmanrl/environments/linear_system.py`
+- Test: `tests/test_gpu_parity.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_gpu_parity.py`:
+
+```python
+import gymnasium as gym
+import numpy as np
+import koopmanrl.environments  # noqa: F401
+
+
+def test_linear_system_f_batch_matches_numpy_cpu():
+    env = gym.make("LinearSystem-v0").unwrapped
+    rng = np.random.default_rng(0)
+    states = rng.uniform(-5, 5, size=(8, env.state_dim))
+    actions = rng.uniform(-5, 5, size=(8, env.action_dim))
+    ref = np.stack([env.f(states[i], actions[i]) for i in range(8)])
+    out = env.f_batch(
+        torch.tensor(states, dtype=torch.float64),
+        torch.tensor(actions, dtype=torch.float64),
+    )
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-9)
+
+
+@CUDA
+def test_linear_system_f_batch_cpu_gpu_parity():
+    env = gym.make("LinearSystem-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(8, env.action_dim, dtype=torch.float64)
+    out_cpu = env.f_batch(s, a)
+    out_gpu = env.f_batch(s.cuda(), a.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)
+
+
+@CUDA
+def test_linear_system_cost_cpu_gpu_parity():
+    env = gym.make("LinearSystem-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(3, env.action_dim, dtype=torch.float64)
+    c_cpu = env.vectorized_cost_fn(s, a)
+    c_gpu = env.vectorized_cost_fn(s.cuda(), a.cuda())
+    assert torch.allclose(c_cpu, c_gpu.cpu(), atol=1e-9)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k linear_system -v`
+Expected: FAIL (`AttributeError: 'LinearSystem' object has no attribute 'f_batch'`).
+
+- [ ] **Step 3: Implement `f_batch`/`reset_batch` and device-aware cost**
+
+In `koopmanrl/environments/linear_system.py`, replace `vectorized_cost_fn` body and add the batch methods:
+
+```python
+    def vectorized_cost_fn(self, states, actions):
+        Q = torch.as_tensor(self.Q, dtype=states.dtype, device=states.device)
+        R = torch.as_tensor(self.R, dtype=states.dtype, device=states.device)
+        ref = torch.as_tensor(self.reference_point, dtype=states.dtype, device=states.device)
+        _states = (states - ref).T
+        state_cost = torch.einsum("bi,ij,bj->b", _states.T, Q, _states.T).unsqueeze(-1)
+        mat = state_cost + torch.pow(actions.T, 2) * R
+        return mat.T
+
+    def f_batch(self, states, actions, generator=None):
+        """Batched dynamics on (batch, state_dim) torch tensors. generator unused (deterministic)."""
+        A = torch.as_tensor(self.A, dtype=states.dtype, device=states.device)
+        B = torch.as_tensor(self.B, dtype=states.dtype, device=states.device)
+        return states @ A.T + actions @ B.T
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
+```
+
+Note: `state_cost` uses `einsum("bi,ij,bj->b", ...)` (equals `diag(_states.T @ Q @ _states)`) to avoid an O(batch²) intermediate.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k linear_system -v`
+Expected: PASS (3, skips for CUDA-only when no GPU).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add koopmanrl/environments/linear_system.py tests/test_gpu_parity.py
+git commit -m "feat: LinearSystem batched dynamics + device-aware cost"
+```
+
+---
+
+## Task 5: FluidFlow substepped-RK4 batched dynamics + device cost
+
+**Files:**
+- Modify: `koopmanrl/environments/fluid_flow.py`
+- Test: `tests/test_gpu_parity.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_gpu_parity.py`:
+
+```python
+def test_fluid_flow_rk4_matches_scipy_accuracy():
+    env = gym.make("FluidFlow-v0").unwrapped
+    rng = np.random.default_rng(1)
+    states = rng.uniform(-1, 1, size=(8, env.state_dim))
+    actions = rng.uniform(-2, 2, size=(8, env.action_dim))
+    ref = np.stack([env.f(states[i], actions[i]) for i in range(8)])  # scipy RK45
+    out = env.f_batch(torch.tensor(states), torch.tensor(actions))
+    # Looser integrator-accuracy tolerance (RK4 substeps vs adaptive RK45)
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-4, rtol=1e-4)
+
+
+@CUDA
+def test_fluid_flow_f_batch_cpu_gpu_parity():
+    env = gym.make("FluidFlow-v0").unwrapped
+    s = torch.rand(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(8, env.action_dim, dtype=torch.float64)
+    out_cpu = env.f_batch(s, a)
+    out_gpu = env.f_batch(s.cuda(), a.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)  # same RK4 both sides → tight
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k fluid_flow -v`
+Expected: FAIL (`AttributeError: ... 'f_batch'`).
+
+- [ ] **Step 3: Implement**
+
+In `koopmanrl/environments/fluid_flow.py`, add `self.n_substeps = 4` in `__init__`, replace `vectorized_cost_fn` body with the device-aware version (identical to Task 3's pattern), and add:
+
+```python
+    def _deriv_batch(self, states, actions):
+        x, y, z = states[:, 0], states[:, 1], states[:, 2]
+        u = actions[:, 0]
+        x_dot = self.mu * x - self.omega * y + self.A * x * z
+        y_dot = self.omega * x + self.mu * y + self.A * y * z + u
+        z_dot = -self.lamb * (z - x.pow(2) - y.pow(2))
+        return torch.stack([x_dot, y_dot, z_dot], dim=1)
+
+    def f_batch(self, states, actions, generator=None):
+        """Batched dynamics via substepped RK4 over a single dt. generator unused (deterministic)."""
+        h = self.dt / self.n_substeps
+        x = states
+        for _ in range(self.n_substeps):
+            k1 = self._deriv_batch(x, actions)
+            k2 = self._deriv_batch(x + 0.5 * h * k1, actions)
+            k3 = self._deriv_batch(x + 0.5 * h * k2, actions)
+            k4 = self._deriv_batch(x + h * k3, actions)
+            x = x + (h / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)
+        return x
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
+```
+
+Use the device-aware `vectorized_cost_fn` from Task 4 (copy that exact method body).
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k fluid_flow -v`
+Expected: PASS. If the accuracy test fails, raise `self.n_substeps` (e.g. 8) and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add koopmanrl/environments/fluid_flow.py tests/test_gpu_parity.py
+git commit -m "feat: FluidFlow batched RK4 dynamics + device-aware cost"
+```
+
+---
+
+## Task 6: Lorenz substepped-RK4 batched dynamics + device cost
+
+**Files:**
+- Modify: `koopmanrl/environments/lorenz.py`
+- Test: `tests/test_gpu_parity.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_gpu_parity.py`:
+
+```python
+def test_lorenz_rk4_matches_scipy_accuracy():
+    env = gym.make("Lorenz-v0").unwrapped
+    rng = np.random.default_rng(2)
+    states = rng.uniform(-10, 10, size=(8, env.state_dim))
+    actions = rng.uniform(-20, 20, size=(8, env.action_dim))
+    ref = np.stack([env.f(states[i], actions[i]) for i in range(8)])
+    out = env.f_batch(torch.tensor(states), torch.tensor(actions))
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-3, rtol=1e-3)
+
+
+@CUDA
+def test_lorenz_f_batch_cpu_gpu_parity():
+    env = gym.make("Lorenz-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64) * 5
+    a = torch.randn(8, env.action_dim, dtype=torch.float64) * 5
+    out_cpu = env.f_batch(s, a)
+    out_gpu = env.f_batch(s.cuda(), a.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k lorenz -v`
+Expected: FAIL (`AttributeError`).
+
+- [ ] **Step 3: Implement**
+
+In `koopmanrl/environments/lorenz.py`, add `self.n_substeps = 4` in `__init__`, replace `vectorized_cost_fn` body with the device-aware version, and add (note the control `u` enters `x_dot`, matching `continuous_f`):
+
+```python
+    def _deriv_batch(self, states, actions):
+        x, y, z = states[:, 0], states[:, 1], states[:, 2]
+        u = actions[:, 0]
+        x_dot = self.sigma * (y - x) + u
+        y_dot = (self.rho - z) * x - y
+        z_dot = x * y - self.beta * z
+        return torch.stack([x_dot, y_dot, z_dot], dim=1)
+
+    def f_batch(self, states, actions, generator=None):
+        h = self.dt / self.n_substeps
+        x = states
+        for _ in range(self.n_substeps):
+            k1 = self._deriv_batch(x, actions)
+            k2 = self._deriv_batch(x + 0.5 * h * k1, actions)
+            k3 = self._deriv_batch(x + 0.5 * h * k2, actions)
+            k4 = self._deriv_batch(x + h * k3, actions)
+            x = x + (h / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)
+        return x
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k lorenz -v`
+Expected: PASS. If accuracy fails, raise `self.n_substeps` and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add koopmanrl/environments/lorenz.py tests/test_gpu_parity.py
+git commit -m "feat: Lorenz batched RK4 dynamics + device-aware cost"
+```
+
+---
+
+## Task 7: DoubleWell batched Euler–Maruyama + device cost
+
+DoubleWell is stochastic. The batched `f_batch` takes an optional `noise` tensor of shape `(batch, 2, 1)` so the deterministic **drift** can be parity-tested with injected noise; when `noise is None` it samples on-device via `generator`.
+
+**Files:**
+- Modify: `koopmanrl/environments/double_well.py`
+- Test: `tests/test_gpu_parity.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_gpu_parity.py`:
+
+```python
+def test_double_well_drift_matches_numpy():
+    env = gym.make("DoubleWell-v0").unwrapped
+    env.reset(seed=0)
+    rng = np.random.default_rng(3)
+    states = rng.uniform(-2, 2, size=(8, env.state_dim))
+    actions = rng.uniform(-5, 5, size=(8, env.action_dim))
+    # numpy drift-only reference (diffusion term zeroed)
+    ref = np.stack([
+        states[i] + env.continuous_f(actions[i])(0, states[i]) * env.dt
+        for i in range(8)
+    ])
+    zero_noise = torch.zeros(8, env.state_dim, 1, dtype=torch.float64)
+    out = env.f_batch(torch.tensor(states), torch.tensor(actions), noise=zero_noise)
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-9)
+
+
+@CUDA
+def test_double_well_drift_cpu_gpu_parity():
+    env = gym.make("DoubleWell-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(8, env.action_dim, dtype=torch.float64)
+    zn = torch.zeros(8, env.state_dim, 1, dtype=torch.float64)
+    out_cpu = env.f_batch(s, a, noise=zn)
+    out_gpu = env.f_batch(s.cuda(), a.cuda(), noise=zn.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k double_well -v`
+Expected: FAIL (`AttributeError`).
+
+- [ ] **Step 3: Implement**
+
+In `koopmanrl/environments/double_well.py`, replace `vectorized_cost_fn` body with the device-aware version, and add. The numpy drift is `b_x = [4x - 4x³, -2y] + u` per `continuous_f`; the diffusion uses `sigma_x = [[0.7, x],[0,0.5]]`:
+
+```python
+    def _drift_batch(self, states, actions):
+        x, y = states[:, 0], states[:, 1]
+        u = actions[:, 0]
+        x_dot = 4 * x - 4 * x.pow(3) + u
+        y_dot = -2 * y + u
+        return torch.stack([x_dot, y_dot], dim=1)
+
+    def f_batch(self, states, actions, generator=None, noise=None):
+        """Batched Euler-Maruyama. noise: (batch, 2, 1) standard-normal draws; sampled if None."""
+        dt = self.dt
+        drift = self._drift_batch(states, actions) * dt
+        if noise is None:
+            noise = torch.randn(states.shape[0], 2, 1, device=states.device, dtype=states.dtype, generator=generator)
+        x = states[:, 0]
+        # sigma_x = [[0.7, x], [0, 0.5]] per-sample
+        sigma = torch.zeros(states.shape[0], 2, 2, device=states.device, dtype=states.dtype)
+        sigma[:, 0, 0] = 0.7
+        sigma[:, 0, 1] = x
+        sigma[:, 1, 1] = 0.5
+        diffusion = torch.bmm(sigma, noise).squeeze(-1) * (dt ** 0.5)
+        return states + drift + diffusion
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_gpu_parity.py -k double_well -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full parity + env suite**
+
+Run: `uv run pytest tests/test_gpu_parity.py tests/test_environments.py -v`
+Expected: all pass (CUDA-only tests run on the GPU box; skipped otherwise).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add koopmanrl/environments/double_well.py tests/test_gpu_parity.py
+git commit -m "feat: DoubleWell batched Euler-Maruyama + device-aware cost"
+```
+
+---
+
+## Task 8: Batched GPU rollout in `generate_koopman_tensor`
+
+Add a batched, device-native rollout to the canonical `generate_koopman_tensor` (in `torch_tensor.py`). When `device` is CUDA it runs all paths in parallel via `reset_batch`/`f_batch`; otherwise it keeps the sequential gym loop (parity reference). Returns a `KoopmanTensor` built on `device`.
+
+**Files:**
+- Modify: `koopmanrl/koopman_tensor/torch_tensor.py`
+- Test: `tests/test_gpu_parity.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_gpu_parity.py`:
+
+```python
+from koopmanrl.koopman_tensor.torch_tensor import generate_koopman_tensor
+
+
+@CUDA
+def test_generate_koopman_tensor_batched_gpu():
+    kt = generate_koopman_tensor(
+        env_id="Lorenz-v0", seed=0, num_paths=16, num_steps_per_path=20,
+        state_order=2, action_order=2, regressor="ols",
+        device=torch.device("cuda"),
+    )
+    assert kt.K.is_cuda
+    assert kt.X.shape[1] == 16 * 20
+    # tensor is usable on-device
+    x = torch.randn(3, 5, dtype=torch.float64, device="cuda")
+    u = torch.randn(1, 5, dtype=torch.float64, device="cuda")
+    assert kt.f(x, u).is_cuda
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_gpu_parity.py::test_generate_koopman_tensor_batched_gpu -v`
+Expected: FAIL (`generate_koopman_tensor` has no `device` parameter / not importable from here yet).
+
+- [ ] **Step 3: Implement**
+
+Add `generate_koopman_tensor` to `koopman_tensor/torch_tensor.py` (import `gymnasium as gym`, `numpy as np`, and `from koopmanrl.koopman_tensor.observables.torch_observables import monomials`; ensure `import koopmanrl.environments` registers the envs):
+
+```python
+def generate_koopman_tensor(
+    env_id, seed, num_paths, num_steps_per_path, state_order, action_order, regressor,
+    device=None, dtype=torch.float64,
+):
+    import koopmanrl.environments  # noqa: F401 (register custom envs)
+
+    device = device or torch.device("cpu")
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    env = gym.make(env_id)
+    env.reset(seed=seed)
+    env.action_space.seed(seed)
+    base = env.unwrapped
+
+    state_dim = env.observation_space.shape[0]
+    action_dim = env.action_space.shape[0]
+
+    if device.type == "cuda" and hasattr(base, "f_batch"):
+        gen = torch.Generator(device=device).manual_seed(seed)
+        low = torch.as_tensor(env.action_space.low, device=device, dtype=dtype)
+        high = torch.as_tensor(env.action_space.high, device=device, dtype=dtype)
+        states = base.reset_batch(num_paths, device=device, dtype=dtype, generator=gen)
+        Xs, Ys, Us = [], [], []
+        for _ in range(num_steps_per_path):
+            actions = low + (high - low) * torch.rand(
+                num_paths, action_dim, device=device, dtype=dtype, generator=gen
+            )
+            next_states = base.f_batch(states, actions, generator=gen)
+            Xs.append(states); Us.append(actions); Ys.append(next_states)
+            states = next_states
+        X = torch.stack(Xs, dim=1).reshape(-1, state_dim).T
+        Y = torch.stack(Ys, dim=1).reshape(-1, state_dim).T
+        U = torch.stack(Us, dim=1).reshape(-1, action_dim).T
+    else:
+        X = torch.zeros((num_paths, num_steps_per_path, state_dim), dtype=dtype)
+        Y = torch.zeros_like(X)
+        U = torch.zeros((num_paths, num_steps_per_path, action_dim), dtype=dtype)
+        for p in range(num_paths):
+            state, _ = env.reset()
+            for s in range(num_steps_per_path):
+                X[p, s] = torch.as_tensor(state, dtype=dtype)
+                action = env.action_space.sample()
+                U[p, s] = torch.as_tensor(action, dtype=dtype)
+                state, _, _, _, _ = env.step(action)
+                Y[p, s] = torch.as_tensor(state, dtype=dtype)
+        n = num_paths * num_steps_per_path
+        X = X.reshape(n, state_dim).T.to(device)
+        Y = Y.reshape(n, state_dim).T.to(device)
+        U = U.reshape(n, action_dim).T.to(device)
+
+    kwargs = dict(phi=monomials(state_order), psi=monomials(action_order), regressor=Regressor(regressor))
+    try:
+        return KoopmanTensor(X, Y, U, dt=base.dt, **kwargs)
+    except Exception:
+        return KoopmanTensor(X, Y, U, **kwargs)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_gpu_parity.py::test_generate_koopman_tensor_batched_gpu -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add koopmanrl/koopman_tensor/torch_tensor.py tests/test_gpu_parity.py
+git commit -m "feat: batched GPU rollout in generate_koopman_tensor"
+```
+
+---
+
+## Task 9: SKVI — canonical tensor, device, vectorized action loop
+
+Replace SKVI's inline `KoopmanTensor`/`generate_koopman_tensor`/`Regressor`/regressors with imports from the canonical module, resolve the device from `--cuda`, add `--fp32`, move all tensors to device, and vectorize the per-action Python loops.
+
+**Files:**
+- Modify: `koopmanrl/soft_koopman_value_iteration.py`
+- Test: existing `tests/test_rl.py` (CPU) + new GPU smoke in Task 13
+
+- [ ] **Step 1: Replace inline tensor code with imports**
+
+Delete the inline `checkMatrixRank`, `checkConditionNumber`, `ols/OLS/SINDy/rrr/RRR/ridgeRegression`, `Regressor`, `KoopmanTensor`, and `generate_koopman_tensor` definitions. Add near the top:
+
+```python
+from koopmanrl.koopman_tensor.torch_tensor import (
+    KoopmanTensor,
+    Regressor,
+    generate_koopman_tensor,
+)
+```
+
+- [ ] **Step 2: Add `--fp32`, resolve device, set dtype**
+
+In `ArgumentParser` add: `fp32: bool = False  # use float32 instead of float64`.
+In `main()` replace `device = torch.device("cpu")` with:
+
+```python
+    from koopmanrl.utils import resolve_device, resolve_dtype  # or add to existing import
+    device = resolve_device(args.cuda)
+    torch.set_default_dtype(resolve_dtype(args.fp32))
+```
+
+Pass `device`/`dtype` into `generate_koopman_tensor(...)`. Move `all_actions` to device: append `.to(device)` to the `all_actions = torch.from_numpy(...).T` expression. Pass `device=device` to `DiscreteKoopmanValueIterationPolicy(...)`.
+
+- [ ] **Step 3: Device-thread the policy**
+
+Add a `device=None` parameter to `DiscreteKoopmanValueIterationPolicy.__init__`; store `self.device = device or torch.device("cpu")`; allocate `self.value_function_weights = torch.zeros((phi_dim, 1), device=self.device)` (and the `requires_grad` branch likewise). In `pis`, `discrete_bellman_error`, and `train`: (a) build batch index tensors on device — `x_batch_indices = torch.as_tensor(np.random.choice(...)).to(self.device)`; (b) replace `costs = torch.Tensor(self.cost(...))` with `costs = self.cost(...)` (it already returns a device tensor); (c) replace each per-action loop.
+
+- [ ] **Step 4: Vectorize the per-action loops**
+
+In all three methods replace the pattern
+
+```python
+        K_us = self.dynamics_model.K_(self.all_actions)
+        phi_x_prime_batch = torch.zeros([num_actions, phi_dim, B])
+        V_x_prime_batch = torch.zeros([num_actions, B])
+        for action_index in range(K_us.shape[0]):
+            phi_x_prime_hat_batch = K_us[action_index] @ phi_x_batch
+            phi_x_prime_batch[action_index] = phi_x_prime_hat_batch
+            V_x_prime_batch[action_index] = self.V_phi_x(phi_x_prime_batch[action_index])
+```
+
+with
+
+```python
+        K_us = self.dynamics_model.K_(self.all_actions)  # (num_actions, phi_dim, phi_dim)
+        phi_x_prime_batch = torch.einsum("aij,jb->aib", K_us, phi_x_batch)  # (num_actions, phi_dim, B)
+        w = self.value_function_weights.squeeze(-1)  # (phi_dim,)
+        V_x_prime_batch = torch.einsum("p,apb->ab", w, phi_x_prime_batch)  # (num_actions, B)
+```
+
+(`phi_xs` in `pis` plays the role of `phi_x_batch`.) Leave the softmax / OLS update logic unchanged.
+
+- [ ] **Step 5: Run CPU regression for SKVI**
+
+Run: `uv run pytest "tests/test_rl.py::test_skvi" -v`
+Expected: 4 passed (CPU path unchanged behavior; numerics within solver tolerance).
+
+- [ ] **Step 6: GPU smoke run**
+
+Run: `uv run python -m koopmanrl.soft_koopman_value_iteration --env_id Lorenz-v0 --total_timesteps 200 --cuda --num_paths 20 --num_steps_per_path 50 --num_training_epochs 5`
+Expected: exit 0, runs without device-mismatch errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add koopmanrl/soft_koopman_value_iteration.py
+git commit -m "feat: SKVI on GPU (canonical tensor, device, vectorized action loop)"
+```
+
+---
+
+## Task 10: SAKC — canonical tensor + device
+
+**Files:**
+- Modify: `koopmanrl/soft_actor_koopman_critic.py`
+- Test: existing `tests/test_rl.py` (CPU) + GPU smoke in Task 13
+
+- [ ] **Step 1: Replace inline tensor code with imports**
+
+Delete the inline `checkMatrixRank/checkConditionNumber/ols/OLS/SINDy/rrr/RRR/ridgeRegression/Regressor/KoopmanTensor/generate_koopman_tensor` definitions. Add:
+
+```python
+from koopmanrl.koopman_tensor.torch_tensor import (
+    KoopmanTensor,
+    Regressor,
+    generate_koopman_tensor,
+)
+```
+
+(Keep the `ReplayBuffer` import — `opt_wrappers` imports `ReplayBuffer` from this module.)
+
+- [ ] **Step 2: Add `--fp32`, resolve device, set dtype**
+
+Add `fp32: bool = False` to `ArgumentParser`. In `main()` replace `device = torch.device("cpu")` with:
+
+```python
+    from koopmanrl.utils import resolve_device, resolve_dtype
+    device = resolve_device(args.cuda)
+    torch.set_default_dtype(resolve_dtype(args.fp32))
+```
+
+Pass `device=device, dtype=resolve_dtype(args.fp32)` to `generate_koopman_tensor(...)`. The networks already use `.to(device)`; the SB3 `ReplayBuffer(..., device, ...)` already takes `device`. `koopman_tensor.phi_f(...)` now runs on-device because the tensor is on `device`.
+
+- [ ] **Step 3: Run CPU regression**
+
+Run: `uv run pytest "tests/test_rl.py::test_sakc" -v`
+Expected: 4 passed.
+
+- [ ] **Step 4: GPU smoke run**
+
+Run: `uv run python -m koopmanrl.soft_actor_koopman_critic --env_id FluidFlow-v0 --total_timesteps 6000 --learning_starts 1000 --cuda --num_paths 20 --num_steps_per_path 50`
+Expected: exit 0, training updates run on GPU without device errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add koopmanrl/soft_actor_koopman_critic.py
+git commit -m "feat: SAKC on GPU (canonical tensor + device)"
+```
+
+---
+
+## Task 11: SAC variants — device resolution
+
+Restore device plumbing in the two CleanRL-derived files. No algorithm-logic changes.
+
+**Files:**
+- Modify: `koopmanrl/sac_continuous_action.py`, `koopmanrl/value_based_sac_continuous_action.py`
+- Test: existing `tests/test_rl.py` (CPU) + GPU smoke in Task 13
+
+- [ ] **Step 1: Edit both files**
+
+In each, replace `device = torch.device("cpu")` with:
+
+```python
+    from koopmanrl.utils import resolve_device
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+```
+
+(The `--cuda` flag already exists in both `ArgumentParser`s; all networks/buffers already use `.to(device)` / `device=`.)
+
+- [ ] **Step 2: Run CPU regression**
+
+Run: `uv run pytest "tests/test_rl.py::test_sac_q" "tests/test_rl.py::test_sac_v" -v`
+Expected: 8 passed.
+
+- [ ] **Step 3: GPU smoke run**
+
+Run: `uv run python -m koopmanrl.sac_continuous_action --env_id LinearSystem-v0 --total_timesteps 6000 --learning_starts 1000 --cuda`
+Run: `uv run python -m koopmanrl.value_based_sac_continuous_action --env_id LinearSystem-v0 --total_timesteps 6000 --learning_starts 1000 --cuda`
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add koopmanrl/sac_continuous_action.py koopmanrl/value_based_sac_continuous_action.py
+git commit -m "feat: restore CUDA device resolution in SAC variants"
+```
+
+---
+
+## Task 12: Optuna wrappers — device/dtype params
+
+**Files:**
+- Modify: `koopmanrl/opt_wrappers.py`
+- Test: smoke import + a short run
+
+- [ ] **Step 1: Update imports**
+
+The wrappers import `generate_koopman_tensor` and `DiscreteKoopmanValueIterationPolicy` from `soft_koopman_value_iteration`, and `Actor/ReplayBuffer/SoftKoopmanVNetwork/SoftQNetwork` from `soft_actor_koopman_critic`. These still exist after Tasks 9–10 (the algos re-export `generate_koopman_tensor` via their import). Confirm: add `from koopmanrl.koopman_tensor.torch_tensor import generate_koopman_tensor` directly to `opt_wrappers.py` to avoid relying on re-export.
+
+- [ ] **Step 2: Add params and resolve device in both wrappers**
+
+Add `cuda: bool = False` and `fp32: bool = False` parameters to `skvi_tuning_wrapper` and `sakc_tuning_wrapper`. Replace `device = torch.device("cpu")` with:
+
+```python
+    from koopmanrl.utils import resolve_device, resolve_dtype
+    device = resolve_device(cuda)
+    torch.set_default_dtype(resolve_dtype(fp32))
+```
+
+Pass `device=device, dtype=resolve_dtype(fp32)` into `generate_koopman_tensor(...)`, pass `device=device` into `DiscreteKoopmanValueIterationPolicy(...)` (skvi wrapper), and append `.to(device)` to the `all_actions` tensor (skvi wrapper).
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+uv run python -c "
+import torch
+from koopmanrl.opt_wrappers import skvi_tuning_wrapper, sakc_tuning_wrapper
+r = skvi_tuning_wrapper(env_id='LinearSystem-v0', total_timesteps=100, number_of_paths=10, number_of_steps_per_path=20, number_of_training_epochs=3, cuda=torch.cuda.is_available())
+print('skvi keys:', list(r.keys())[:2])
+r = sakc_tuning_wrapper(env_id='LinearSystem-v0', total_timesteps=2000, learning_starts=500, number_of_paths=10, number_of_steps_per_path=20, cuda=torch.cuda.is_available())
+print('sakc keys:', list(r.keys())[:2])
+"
+```
+Expected: prints both key lists, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add koopmanrl/opt_wrappers.py
+git commit -m "feat: device/dtype support in Optuna wrappers"
+```
+
+---
+
+## Task 13: GPU smoke tests in the suite + full validation + docs
+
+**Files:**
+- Modify: `tests/test_rl.py`, `koopmanrl/environments/AGENTS.md`
+
+- [ ] **Step 1: Add CUDA smoke tests to `tests/test_rl.py`**
+
+Append:
+
+```python
+import torch
+
+cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_skvi_cuda(env_id):
+    result = run_module(
+        "koopmanrl.soft_koopman_value_iteration",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_sakc_cuda(env_id):
+    result = run_module(
+        "koopmanrl.soft_actor_koopman_critic",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_sac_q_cuda(env_id):
+    result = run_module(
+        "koopmanrl.sac_continuous_action",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_sac_v_cuda(env_id):
+    result = run_module(
+        "koopmanrl.value_based_sac_continuous_action",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
+    )
+    assert result.returncode == 0, result.stderr
+```
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `uv run pytest tests/test_environments.py tests/test_gpu_parity.py tests/test_device_utils.py tests/test_rl.py -v`
+Expected: all CPU tests pass (28 original + new), all CUDA tests pass on the GPU box. Investigate and fix any failure before proceeding (use systematic-debugging).
+
+- [ ] **Step 3: Confirm tensors are actually on the GPU**
+
+Run: `uv run python -c "
+import torch
+from koopmanrl.koopman_tensor.torch_tensor import generate_koopman_tensor
+kt = generate_koopman_tensor('Lorenz-v0', 0, 32, 50, 2, 2, 'ols', device=torch.device('cuda'))
+print('K on cuda:', kt.K.is_cuda, '| B on cuda:', kt.B.is_cuda, '| X on cuda:', kt.X.is_cuda)
+"`
+Expected: `K on cuda: True | B on cuda: True | X on cuda: True`.
+
+- [ ] **Step 4: Update env AGENTS doc**
+
+In `koopmanrl/environments/AGENTS.md`, change the Design Guide bullet "Environments are allowed to run with FP64, and are run on CPU" to note: the gym single-env path is FP64/CPU (parity reference), and each env additionally exposes batched, device-aware `f_batch`/`reset_batch` (substepped RK4 for FluidFlow/Lorenz, Euler–Maruyama for DoubleWell) used for GPU data-gen and training.
+
+- [ ] **Step 5: Run lint**
+
+Run: `uv run pre-commit run --all-files`
+Expected: passes (fix any ruff/isort findings it reports).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_rl.py koopmanrl/environments/AGENTS.md
+git commit -m "test: GPU smoke tests; docs: note batched GPU env path"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §1 device foundation → Task 1, 9–12. §2 canonical tensor → Tasks 3, 8, 9, 10. §3 observables → Task 2. §4 batched envs + device cost → Tasks 4–7. §5 batched data-gen → Task 8. §6 algorithm wiring → Tasks 9–12. §Validation parity + smoke → Tasks 2–8 (parity), 13 (smoke + full run). §Non-goals (LQR untouched) respected — no LQR task. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows real code; commands have expected output. ✓
+
+**Type/name consistency:** `f_batch(states, actions, generator=None)` everywhere (DoubleWell adds `noise=None`); `reset_batch(n, device, dtype, generator)` everywhere; `resolve_device`/`resolve_dtype` names consistent; `generate_koopman_tensor(..., device=, dtype=)` consistent across Tasks 8–12; `vectorized_cost_fn` einsum form identical across envs. ✓
+
+**Known risk handled in-plan:** Task 3 Step 6 carries the `lstsq`-on-CUDA fallback.

--- a/docs/superpowers/specs/2026-05-22-gpu-koopmanrl-design.md
+++ b/docs/superpowers/specs/2026-05-22-gpu-koopmanrl-design.md
@@ -1,0 +1,191 @@
+# GPU-enabling KoopmanRL: environments & algorithms
+
+**Date:** 2026-05-22
+**Status:** Approved (design); pending implementation plan
+**Author:** Ludger Paehler (with Claude)
+
+## Goal
+
+Make the KoopmanRL package run its reinforcement-learning algorithms **and** its 4 control
+environments on an NVIDIA GPU (target hardware: RTX 5090 / Blackwell `sm_120`, validated with
+`torch==2.9.1+cu128`). The Koopman-assisted algorithms (SKVI, SAKC) currently contain parts that
+cannot run on GPU at all (numpy round-trips inside the Koopman tensor, default-device tensor
+allocations, hardcoded `device="cpu"`). This effort fixes that and validates the GPU paths against
+the existing CPU behavior.
+
+## Baseline (already verified on CPU, 2026-05-22)
+
+- `tests/test_environments.py`: 8/8 passed.
+- `tests/test_rl.py`: 20/20 passed (LQR, SAC-Q, SAC-V, SKVI, SAKC × {LinearSystem, FluidFlow,
+  Lorenz, DoubleWell}).
+
+This is the reference behavior the GPU port is validated against.
+
+## Decisions (locked)
+
+| Topic | Decision |
+|---|---|
+| Env GPU model | **Hybrid**: keep the gym single-env numpy API; add batched, device-native env dynamics for data-gen + training. |
+| ODE integrator (FluidFlow/Lorenz) | **Substepped fixed-step RK4** in torch, batched. Replaces `scipy.integrate.solve_ivp` (RK45) on the batched GPU path only. |
+| Precision | **FP64 default, `--fp32` opt-in.** |
+| Validation | **Parity tests added to the suite** (CPU vs GPU within tolerance, plus GPU smoke runs). |
+| Algorithm scope | SKVI, SAKC, both Optuna wrappers, **both** CleanRL SAC variants. **LQR stays CPU** (classical Riccati via `control`/scipy). |
+| Code structure | **Single source of truth**: `koopman_tensor/torch_tensor.py` becomes the one device-aware `KoopmanTensor`; SKVI & SAKC import it instead of their inline copies. |
+| Default device | **`--cuda` stays opt-in** (default CPU, preserves exact reproducibility of existing runs). Tests exercise `--cuda`. |
+
+## Non-goals
+
+- Porting **LQR** to GPU (classical scipy/`control` Riccati solve; no GPU benefit).
+- Changing the **default device** (GPU is opt-in via `--cuda`).
+- Changing SAC **algorithm logic** — only restoring device plumbing.
+- Touching `interpretability_discrete_value_iteration.py` beyond optional alignment (it is already
+  device-aware and not in the test suite).
+
+---
+
+## Architecture
+
+### 1. Device & dtype foundation
+
+Add helpers to `koopmanrl/utils.py`:
+
+```python
+def resolve_device(cuda: bool) -> torch.device:
+    return torch.device("cuda" if (cuda and torch.cuda.is_available()) else "cpu")
+
+def resolve_dtype(fp32: bool) -> torch.dtype:
+    return torch.float32 if fp32 else torch.float64
+```
+
+- Replace the hardcoded `device = torch.device("cpu")` in `soft_koopman_value_iteration.py`,
+  `soft_actor_koopman_critic.py`, `sac_continuous_action.py`,
+  `value_based_sac_continuous_action.py`, and `opt_wrappers.py` with `resolve_device(args.cuda)`.
+  (The `--cuda` flag is currently parsed but ignored in all of these.)
+- Add a `--fp32` flag (default off → FP64) to the Koopman algorithms and the Optuna wrappers.
+  Default dtype handling stays FP64 unless `--fp32` is set.
+
+### 2. Canonical Koopman tensor (`koopman_tensor/torch_tensor.py`)
+
+Make this the single device-aware implementation; have SKVI & SAKC import `KoopmanTensor`,
+`Regressor`, `generate_koopman_tensor` from here (delete the inline duplicates). Fixes the three
+CPU detours:
+
+1. **`kron_matrix` Python loop** (`for i in range(N): torch.kron(...)`) →
+   `torch.einsum("in,jn->ijn", Psi_U, Phi_X).reshape(psi_dim * phi_dim, N)`.
+   This matches `torch.kron(u_col, x_col)` ordering: element `[i*phi_dim + j, n] = Psi_U[i,n]*Phi_X[j,n]`.
+2. **`self.M.numpy()` + per-row Fortran-order reshape into `self.K`** →
+   `K = M.reshape(phi_dim, psi_dim, phi_dim).transpose(-1, -2).contiguous()`.
+   (F-order reshape of a length-`phi_dim*psi_dim` row into `(phi_dim, psi_dim)` equals the C-order
+   reshape into `(psi_dim, phi_dim)` transposed.) Stays on-device, no numpy.
+3. Constants and inputs carry `device`/`dtype` (inferred from input `X` when it is a tensor).
+
+The regressors (`ols/rrr/sindy/ridge`) are already `torch.linalg` and GPU-capable.
+
+**Risk:** `torch.linalg.lstsq` on CUDA uses the `gels` driver (assumes full rank, ignores `rcond`).
+Mitigation: the existing rank checks; validate numerically; fall back to `torch.linalg.pinv`-based
+solve (or a one-time CPU solve) for the tensor build if instability appears. The tensor build is a
+one-time, small operation (phi_dim ≈ 10, N ≈ 30k).
+
+### 3. Device-aware observables (`koopman_tensor/observables/torch_observables.py`)
+
+`monomials.__call__/diff/ddiff` must allocate output tensors on `x.device`/`x.dtype` and move the
+powers matrix `c` to `x.device` (today they create CPU default-device tensors, e.g.
+`torch.ones([n, m])`). `koopman_observables.py` re-exports/aligns with this canonical module.
+
+### 4. Batched, device-native env dynamics
+
+Each env (`LinearSystem`, `FluidFlow`, `Lorenz`, `DoubleWell`) gains vectorized, device-aware batch
+ops on `(batch, state_dim)` torch tensors. **The existing numpy `step`/`f`/`reset`/`continuous_f`
+stay untouched** — they remain the gym-compatible CPU path and the parity reference.
+
+- `f_batch(states, actions) -> next_states` (batch, state_dim):
+  - LinearSystem: `states @ A.T + actions @ B.T`.
+  - FluidFlow / Lorenz: substepped torch RK4 of `continuous_f`, batched (`n_substeps` configurable,
+    default chosen to match RK45 accuracy at dt=0.01).
+  - DoubleWell: torch Euler–Maruyama (drift + state-dependent diffusion), torch RNG.
+- `reset_batch(n, generator) -> states`: uniform sampling within state bounds, on device.
+- Env constants (`A, B, Q, R, reference_point, continuous_A/B`) lazily converted to torch tensors on
+  the requested device/dtype and cached.
+- `vectorized_cost_fn` made device-correct: convert `Q/R/reference_point` to torch on the input
+  states' device. (Today it mixes numpy `Q/R` with torch tensors — works on CPU by coincidence,
+  breaks on GPU.)
+
+### 5. Batched GPU rollout for Koopman data generation
+
+`generate_koopman_tensor` gains a batched code path: when on CUDA, collect `X/Y/U` by running all
+`num_paths` rollouts **in parallel** via `reset_batch` + `f_batch` for `num_steps_per_path` steps,
+with random actions sampled on-device within the action bounds. This replaces ~`num_paths *
+num_steps_per_path` (≈30k) sequential `solve_ivp`/`step` calls with `num_steps_per_path` batched GPU
+steps — the single biggest speedup. The current sequential gym loop is retained as the CPU
+fallback / parity reference.
+
+### 6. Algorithm wiring
+
+- **SKVI** (`soft_koopman_value_iteration.py`):
+  - Import canonical `KoopmanTensor`; move tensor (`K, B, Phi_X, X`), `all_actions`, value-function
+    weights, and costs to `device`.
+  - `DiscreteKoopmanValueIterationPolicy` takes a `device`; its internal `torch.zeros([...])`
+    allocations (in `pis`, `discrete_bellman_error`, `train`) get `device=`.
+  - **Vectorize the per-action Python loop** (`for action_index in range(K_us.shape[0])`) into
+    `torch.einsum("aij,jb->aib", K_us, phi_x_batch)` followed by a batched value evaluation —
+    removes the 101-iteration loop (big GPU win) in `pis`, `discrete_bellman_error`, and `train`.
+- **SAKC** (`soft_actor_koopman_critic.py`): device resolution; SB3 `ReplayBuffer(device=cuda)`;
+  `koopman_tensor.phi_f` and `SoftKoopmanVNetwork` on device; obs/action tensors on device.
+- **SAC variants** (`sac_continuous_action.py`, `value_based_sac_continuous_action.py`): restore
+  CleanRL-style device resolution from the hardcoded CPU. No algorithm-logic changes.
+- **Optuna wrappers** (`opt_wrappers.py`): same device wiring; add `cuda`/`fp32` parameters.
+
+---
+
+## Validation & testing
+
+### New: `tests/test_gpu_parity.py` (skipped when CUDA unavailable)
+
+- **Env dynamics parity (per env):**
+  - CPU-RK4 vs GPU-RK4 of `f_batch` on identical inputs → **tight** parity (FP64, atol≈1e-9).
+  - GPU-RK4 vs CPU numpy `f` (RK45 reference) → closeness within an **integrator tolerance**
+    (looser, reflects RK4-vs-RK45 difference), single-step / short-horizon only (Lorenz is chaotic;
+    no long-trajectory parity).
+  - DoubleWell: parity on the **drift** term with injected identical noise.
+- **Cost parity:** `vectorized_cost_fn` CPU vs GPU within tol.
+- **Koopman tensor parity:** build from identical `X/Y/U` on CPU vs GPU → `K`, `B`, `M`, `phi_f`,
+  `f` match within tol; `monomials` outputs match.
+
+### Extend `tests/test_rl.py`
+
+- Add `--cuda` smoke runs (assert returncode 0) for SKVI, SAKC, and the SAC variants on at least one
+  env. Existing CPU tests remain unchanged.
+
+### Acceptance criteria
+
+1. All existing CPU tests still pass (28/28).
+2. New GPU parity tests pass on the RTX 5090.
+3. SKVI, SAKC, SAC-Q, SAC-V run end-to-end with `--cuda` on all 4 envs (returncode 0), with tensors
+   confirmed resident on the GPU.
+4. The Koopman tensor build and SKVI action evaluation contain no numpy round-trips or Python
+   per-element loops on the hot path.
+
+## Risks & mitigations
+
+- **`lstsq` on CUDA** (full-rank `gels`, no `rcond`): rely on rank checks; fall back to `pinv`/CPU
+  solve for the one-time build if needed.
+- **FP64 on consumer Blackwell** (~1:64 throughput): `--fp32` opt-in for speed.
+- **Lorenz chaos**: parity only at single-step/short horizon, not full trajectories.
+- **DoubleWell stochastic RNG**: numpy↔torch draws can't match bit-for-bit; parity on drift with
+  injected noise.
+- **Triplicated KoopmanTensor**: consolidating to one module changes imports in SKVI/SAKC and
+  `opt_wrappers`; verify `generate_tensor.py` (already importing the canonical module) still works.
+
+## Affected files
+
+- `koopmanrl/utils.py` (device/dtype helpers)
+- `koopmanrl/koopman_tensor/torch_tensor.py` (canonical, device-aware; add `generate_koopman_tensor`)
+- `koopmanrl/koopman_tensor/observables/torch_observables.py` (device-aware)
+- `koopmanrl/koopman_observables.py` (align/re-export)
+- `koopmanrl/environments/{linear_system,fluid_flow,lorenz,double_well}.py` (batch ops, device-aware cost)
+- `koopmanrl/soft_koopman_value_iteration.py` (import canonical tensor; device; vectorize action loop)
+- `koopmanrl/soft_actor_koopman_critic.py` (import canonical tensor; device)
+- `koopmanrl/sac_continuous_action.py`, `koopmanrl/value_based_sac_continuous_action.py` (device)
+- `koopmanrl/opt_wrappers.py` (device/dtype params)
+- `tests/test_gpu_parity.py` (new), `tests/test_rl.py` (GPU smoke runs)
+- Docs: update `koopmanrl/environments/AGENTS.md` ("run on CPU" → CPU + batched GPU path).

--- a/koopmanrl/environments/AGENTS.md
+++ b/koopmanrl/environments/AGENTS.md
@@ -17,10 +17,11 @@ environments/
 
 ## Design Guide
 
-All four environments follow two guiding principles:
+All four environments follow these guiding principles:
 
 * All environments follow the Gymnasium API
-* Environments are allowed to run with FP64, and are run on CPU
+* The Gymnasium single-env API remains FP64/CPU and serves as the parity reference
+* Each environment additionally exposes batched, device-aware `f_batch`/`reset_batch` (substepped RK4 for FluidFlow/Lorenz, Euler-Maruyama for DoubleWell, linear algebra for LinearSystem) plus a device-aware `vectorized_cost_fn`, used for GPU data-generation and training
 
 ## Working Checklist
 

--- a/koopmanrl/environments/double_well.py
+++ b/koopmanrl/environments/double_well.py
@@ -118,7 +118,7 @@ class DoubleWell(gym.Env):
         sigma[:, 0, 0] = 0.7
         sigma[:, 0, 1] = x
         sigma[:, 1, 1] = 0.5
-        diffusion = torch.bmm(sigma, noise).squeeze(-1) * (dt ** 0.5)
+        diffusion = torch.bmm(sigma, noise).squeeze(-1) * (dt**0.5)
         return states + drift + diffusion
 
     def reset_batch(self, n, device, dtype=torch.float64, generator=None):

--- a/koopmanrl/environments/double_well.py
+++ b/koopmanrl/environments/double_well.py
@@ -88,13 +88,43 @@ class DoubleWell(gym.Env):
         return -self.cost_fn(state, action)
 
     def vectorized_cost_fn(self, states, actions):
-        _states = (states - self.reference_point).T
-        mat = torch.diag(_states.T @ self.Q @ _states).unsqueeze(-1) + torch.pow(actions.T, 2) * self.R
-
+        Q = torch.as_tensor(self.Q, dtype=states.dtype, device=states.device)
+        R = torch.as_tensor(self.R, dtype=states.dtype, device=states.device)
+        ref = torch.as_tensor(self.reference_point, dtype=states.dtype, device=states.device)
+        _states = (states - ref).T
+        state_cost = torch.einsum("bi,ij,bj->b", _states.T, Q, _states.T).unsqueeze(-1)
+        mat = state_cost + torch.pow(actions.T, 2) * R
         return mat.T
 
     def vectorized_reward_fn(self, states, actions):
         return -self.vectorized_cost_fn(states, actions)
+
+    def _drift_batch(self, states, actions):
+        x, y = states[:, 0], states[:, 1]
+        u = actions[:, 0]
+        x_dot = 4 * x - 4 * x.pow(3) + u
+        y_dot = -2 * y + u
+        return torch.stack([x_dot, y_dot], dim=1)
+
+    def f_batch(self, states, actions, generator=None, noise=None):
+        """Batched Euler-Maruyama. noise: (batch, 2, 1) standard-normal draws; sampled if None."""
+        dt = self.dt
+        drift = self._drift_batch(states, actions) * dt
+        if noise is None:
+            noise = torch.randn(states.shape[0], 2, 1, device=states.device, dtype=states.dtype, generator=generator)
+        x = states[:, 0]
+        # sigma_x = [[0.7, x], [0, 0.5]] per-sample
+        sigma = torch.zeros(states.shape[0], 2, 2, device=states.device, dtype=states.dtype)
+        sigma[:, 0, 0] = 0.7
+        sigma[:, 0, 1] = x
+        sigma[:, 1, 1] = 0.5
+        diffusion = torch.bmm(sigma, noise).squeeze(-1) * (dt ** 0.5)
+        return states + drift + diffusion
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
 
     def continuous_f(self, action=None):
         """

--- a/koopmanrl/environments/fluid_flow.py
+++ b/koopmanrl/environments/fluid_flow.py
@@ -33,6 +33,7 @@ class FluidFlow(gym.Env):
         self.lamb = 1
 
         self.dt = dt
+        self.n_substeps = 4
         self.max_episode_steps = max_episode_steps
 
         # For LQR
@@ -102,13 +103,41 @@ class FluidFlow(gym.Env):
         return -self.cost_fn(state, action)
 
     def vectorized_cost_fn(self, states, actions):
-        _states = (states - self.reference_point).T
-        mat = torch.diag(_states.T @ self.Q @ _states).unsqueeze(-1) + torch.pow(actions.T, 2) * self.R
-
+        Q = torch.as_tensor(self.Q, dtype=states.dtype, device=states.device)
+        R = torch.as_tensor(self.R, dtype=states.dtype, device=states.device)
+        ref = torch.as_tensor(self.reference_point, dtype=states.dtype, device=states.device)
+        _states = (states - ref).T
+        state_cost = torch.einsum("bi,ij,bj->b", _states.T, Q, _states.T).unsqueeze(-1)
+        mat = state_cost + torch.pow(actions.T, 2) * R
         return mat.T
 
     def vectorized_reward_fn(self, states, actions):
         return -self.vectorized_cost_fn(states, actions)
+
+    def _deriv_batch(self, states, actions):
+        x, y, z = states[:, 0], states[:, 1], states[:, 2]
+        u = actions[:, 0]
+        x_dot = self.mu * x - self.omega * y + self.A * x * z
+        y_dot = self.omega * x + self.mu * y + self.A * y * z + u
+        z_dot = -self.lamb * (z - x.pow(2) - y.pow(2))
+        return torch.stack([x_dot, y_dot, z_dot], dim=1)
+
+    def f_batch(self, states, actions, generator=None):
+        """Batched dynamics via substepped RK4 over a single dt. generator unused (deterministic)."""
+        h = self.dt / self.n_substeps
+        x = states
+        for _ in range(self.n_substeps):
+            k1 = self._deriv_batch(x, actions)
+            k2 = self._deriv_batch(x + 0.5 * h * k1, actions)
+            k3 = self._deriv_batch(x + 0.5 * h * k2, actions)
+            k4 = self._deriv_batch(x + h * k3, actions)
+            x = x + (h / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)
+        return x
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
 
     def continuous_f(self, action=None):
         """

--- a/koopmanrl/environments/linear_system.py
+++ b/koopmanrl/environments/linear_system.py
@@ -84,10 +84,24 @@ class LinearSystem(gym.Env):
         return -self.cost_fn(state, action)
 
     def vectorized_cost_fn(self, states, actions):
-        _states = (states - self.reference_point).T
-        mat = torch.diag(_states.T @ self.Q @ _states).unsqueeze(-1) + torch.pow(actions.T, 2) * self.R
-
+        Q = torch.as_tensor(self.Q, dtype=states.dtype, device=states.device)
+        R = torch.as_tensor(self.R, dtype=states.dtype, device=states.device)
+        ref = torch.as_tensor(self.reference_point, dtype=states.dtype, device=states.device)
+        _states = (states - ref).T
+        state_cost = torch.einsum("bi,ij,bj->b", _states.T, Q, _states.T).unsqueeze(-1)
+        mat = state_cost + torch.pow(actions.T, 2) * R
         return mat.T
+
+    def f_batch(self, states, actions, generator=None):
+        """Batched dynamics on (batch, state_dim) torch tensors. generator unused (deterministic)."""
+        A = torch.as_tensor(self.A, dtype=states.dtype, device=states.device)
+        B = torch.as_tensor(self.B, dtype=states.dtype, device=states.device)
+        return states @ A.T + actions @ B.T
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
 
     def vectorized_reward_fn(self, states, actions):
         return -self.vectorized_cost_fn(states, actions)

--- a/koopmanrl/environments/lorenz.py
+++ b/koopmanrl/environments/lorenz.py
@@ -28,6 +28,7 @@ class Lorenz(gym.Env):
         # self.action_range = [-500.0, 500.0]
 
         self.dt = dt
+        self.n_substeps = 4
         self.max_episode_steps = max_episode_steps
 
         # Dynamics
@@ -94,13 +95,41 @@ class Lorenz(gym.Env):
         return -self.cost_fn(state, action)
 
     def vectorized_cost_fn(self, states, actions):
-        _states = (states - self.reference_point).T
-        mat = torch.diag(_states.T @ self.Q @ _states).unsqueeze(-1) + torch.pow(actions.T, 2) * self.R
-
+        Q = torch.as_tensor(self.Q, dtype=states.dtype, device=states.device)
+        R = torch.as_tensor(self.R, dtype=states.dtype, device=states.device)
+        ref = torch.as_tensor(self.reference_point, dtype=states.dtype, device=states.device)
+        _states = (states - ref).T
+        state_cost = torch.einsum("bi,ij,bj->b", _states.T, Q, _states.T).unsqueeze(-1)
+        mat = state_cost + torch.pow(actions.T, 2) * R
         return mat.T
 
     def vectorized_reward_fn(self, states, actions):
         return -self.vectorized_cost_fn(states, actions)
+
+    def _deriv_batch(self, states, actions):
+        x, y, z = states[:, 0], states[:, 1], states[:, 2]
+        u = actions[:, 0]
+        x_dot = self.sigma * (y - x) + u
+        y_dot = (self.rho - z) * x - y
+        z_dot = x * y - self.beta * z
+        return torch.stack([x_dot, y_dot, z_dot], dim=1)
+
+    def f_batch(self, states, actions, generator=None):
+        """Batched dynamics via substepped RK4 over a single dt. generator unused (deterministic)."""
+        h = self.dt / self.n_substeps
+        x = states
+        for _ in range(self.n_substeps):
+            k1 = self._deriv_batch(x, actions)
+            k2 = self._deriv_batch(x + 0.5 * h * k1, actions)
+            k3 = self._deriv_batch(x + 0.5 * h * k2, actions)
+            k4 = self._deriv_batch(x + h * k3, actions)
+            x = x + (h / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)
+        return x
+
+    def reset_batch(self, n, device, dtype=torch.float64, generator=None):
+        low = torch.as_tensor(self.state_minimums, device=device, dtype=dtype)
+        high = torch.as_tensor(self.state_maximums, device=device, dtype=dtype)
+        return low + (high - low) * torch.rand(n, self.state_dim, device=device, dtype=dtype, generator=generator)
 
     def continuous_f(self, action=None):
         """

--- a/koopmanrl/koopman_tensor/generate_tensor.py
+++ b/koopmanrl/koopman_tensor/generate_tensor.py
@@ -1,11 +1,11 @@
 import gymnasium as gym
-import koopmanrl.environments  # noqa: F401 — register custom environments
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from matplotlib.animation import FuncAnimation
 from tap import Tap
 
+import koopmanrl.environments  # noqa: F401 — register custom environments
 from koopmanrl.koopman_tensor.observables import torch_observables as observables
 from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor
 from koopmanrl.koopman_tensor.utils import save_tensor

--- a/koopmanrl/koopman_tensor/generate_tensor.py
+++ b/koopmanrl/koopman_tensor/generate_tensor.py
@@ -1,4 +1,5 @@
 import gymnasium as gym
+import koopmanrl.environments  # noqa: F401 — register custom environments
 import matplotlib.pyplot as plt
 import numpy as np
 import torch

--- a/koopmanrl/koopman_tensor/observables/torch_observables.py
+++ b/koopmanrl/koopman_tensor/observables/torch_observables.py
@@ -31,7 +31,9 @@ class monomials(object):
         Evaluate all monomials of order up to p for all data points in x.
         """
         [d, m] = x.shape  # d = dimension of state space, m = number of test points
-        c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)  # matrix containing all powers for the monomials
+        c = allMonomialPowers(d, self.p).to(
+            device=x.device, dtype=x.dtype
+        )  # matrix containing all powers for the monomials
         n = c.shape[1]  # number of monomials
         y = torch.ones([n, m], device=x.device, dtype=x.dtype)
         for i in range(n):
@@ -44,7 +46,9 @@ class monomials(object):
         Compute partial derivatives for all data points in x.
         """
         [d, m] = x.shape  # d = dimension of state space, m = number of test points
-        c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)  # matrix containing all powers for the monomials
+        c = allMonomialPowers(d, self.p).to(
+            device=x.device, dtype=x.dtype
+        )  # matrix containing all powers for the monomials
         n = c.shape[1]  # number of monomials
         y = torch.zeros([n, d, m], device=x.device, dtype=x.dtype)
         for i in range(n):  # for all monomials
@@ -66,7 +70,9 @@ class monomials(object):
         Compute second order derivatives for all data points in x.
         """
         [d, m] = x.shape  # d = dimension of state space, m = number of test points
-        c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)  # matrix containing all powers for the monomials
+        c = allMonomialPowers(d, self.p).to(
+            device=x.device, dtype=x.dtype
+        )  # matrix containing all powers for the monomials
         n = c.shape[1]  # number of monomials
         y = torch.zeros([n, d, d, m], device=x.device, dtype=x.dtype)
         for i in range(n):  # for all monomials

--- a/koopmanrl/koopman_tensor/observables/torch_observables.py
+++ b/koopmanrl/koopman_tensor/observables/torch_observables.py
@@ -31,12 +31,11 @@ class monomials(object):
         Evaluate all monomials of order up to p for all data points in x.
         """
         [d, m] = x.shape  # d = dimension of state space, m = number of test points
-        c = allMonomialPowers(d, self.p)  # matrix containing all powers for the monomials
+        c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)  # matrix containing all powers for the monomials
         n = c.shape[1]  # number of monomials
-        y = torch.ones([n, m])
+        y = torch.ones([n, m], device=x.device, dtype=x.dtype)
         for i in range(n):
             for j in range(d):
-                # y[i] = y[i] * torch.pow(x[j], c[j, i])
                 y[i] *= torch.pow(x[j], c[j, i])
         return y
 
@@ -45,19 +44,19 @@ class monomials(object):
         Compute partial derivatives for all data points in x.
         """
         [d, m] = x.shape  # d = dimension of state space, m = number of test points
-        c = allMonomialPowers(d, self.p)  # matrix containing all powers for the monomials
+        c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)  # matrix containing all powers for the monomials
         n = c.shape[1]  # number of monomials
-        y = torch.zeros([n, d, m])
+        y = torch.zeros([n, d, m], device=x.device, dtype=x.dtype)
         for i in range(n):  # for all monomials
             for j in range(d):  # for all dimensions
-                e = c[:, i].copy()  # exponents of ith monomial
+                e = c[:, i].clone()  # exponents of ith monomial
                 a = e[j]
                 e[j] = e[j] - 1  # derivative w.r.t. j
 
                 if torch.any(e < 0):
                     continue  # nothing to do, already zero
 
-                y[i, j, :] = a * torch.ones([1, m])
+                y[i, j, :] = a * torch.ones([1, m], device=x.device, dtype=x.dtype)
                 for k in range(d):
                     y[i, j, :] = y[i, j, :] * torch.pow(x[k, :], e[k])
         return y
@@ -67,13 +66,13 @@ class monomials(object):
         Compute second order derivatives for all data points in x.
         """
         [d, m] = x.shape  # d = dimension of state space, m = number of test points
-        c = allMonomialPowers(d, self.p)  # matrix containing all powers for the monomials
+        c = allMonomialPowers(d, self.p).to(device=x.device, dtype=x.dtype)  # matrix containing all powers for the monomials
         n = c.shape[1]  # number of monomials
-        y = torch.zeros([n, d, d, m])
+        y = torch.zeros([n, d, d, m], device=x.device, dtype=x.dtype)
         for i in range(n):  # for all monomials
             for j1 in range(d):  # for all dimensions
                 for j2 in range(d):  # for all dimensions
-                    e = c[:, i].copy()  # exponents of ith monomial
+                    e = c[:, i].clone()  # exponents of ith monomial
                     a = e[j1]
                     e[j1] = e[j1] - 1  # derivative w.r.t. j1
                     a *= e[j2]
@@ -82,7 +81,7 @@ class monomials(object):
                     if torch.any(e < 0):
                         continue  # nothing to do, already zero
 
-                    y[i, j1, j2, :] = a * torch.ones([1, m])
+                    y[i, j1, j2, :] = a * torch.ones([1, m], device=x.device, dtype=x.dtype)
                     for k in range(d):
                         y[i, j1, j2, :] = y[i, j1, j2, :] * torch.pow(x[k, :], e[k])
         return y

--- a/koopmanrl/koopman_tensor/torch_tensor.py
+++ b/koopmanrl/koopman_tensor/torch_tensor.py
@@ -277,8 +277,15 @@ class KoopmanTensor:
 
 
 def generate_koopman_tensor(
-    env_id, seed, num_paths, num_steps_per_path, state_order, action_order, regressor,
-    device=None, dtype=torch.float64,
+    env_id,
+    seed,
+    num_paths,
+    num_steps_per_path,
+    state_order,
+    action_order,
+    regressor,
+    device=None,
+    dtype=torch.float64,
 ):
     """
     Generate a KoopmanTensor from rollouts of the given Gymnasium environment.
@@ -333,9 +340,7 @@ def generate_koopman_tensor(
         states = base.reset_batch(num_paths, device=device, dtype=dtype, generator=gen)
         Xs, Ys, Us = [], [], []
         for _ in range(num_steps_per_path):
-            actions = low + (high - low) * torch.rand(
-                num_paths, action_dim, device=device, dtype=dtype, generator=gen
-            )
+            actions = low + (high - low) * torch.rand(num_paths, action_dim, device=device, dtype=dtype, generator=gen)
             next_states = base.f_batch(states, actions, generator=gen)
             Xs.append(states)
             Us.append(actions)

--- a/koopmanrl/koopman_tensor/torch_tensor.py
+++ b/koopmanrl/koopman_tensor/torch_tensor.py
@@ -1,6 +1,5 @@
 from enum import Enum
 
-import numpy as np
 import torch
 
 torch.set_default_dtype(torch.float64)
@@ -44,6 +43,9 @@ def SINDy(Theta, dXdt, lamb=0.05):
 
 
 def ols(X, Y):
+    # On CUDA, lstsq only supports the gels (full-rank) driver and silently ignores
+    # rcond; for the full-rank inputs used here it matches the CPU solution to machine
+    # precision, so no special CUDA branch is needed. Keep the CPU path unchanged.
     return torch.linalg.lstsq(X, Y, rcond=None).solution
 
 
@@ -66,7 +68,8 @@ def RRR(X, Y, rank=8):
 
 
 def ridgeRegression(X, y, lamb=0.05):
-    return torch.linalg.inv(X.T @ X + (lamb * torch.eye(X.shape[1]))) @ X.T @ y
+    eye = torch.eye(X.shape[1], device=X.device, dtype=X.dtype)
+    return torch.linalg.inv(X.T @ X + lamb * eye) @ X.T @ y
 
 
 """ Regressor enum """
@@ -174,9 +177,10 @@ class KoopmanTensor:
         print("\n")
 
         # Build matrix of kronecker products between u_i and x_i for all 0 <= i <= N
-        self.kron_matrix = torch.empty([self.psi_dim * self.phi_dim, self.N])
-        for i in range(self.N):
-            self.kron_matrix[:, i] = torch.kron(self.Psi_U[:, i], self.Phi_X[:, i])
+        # torch.kron(Psi_U[:,i], Phi_X[:,i])[a*phi_dim + b] = Psi_U[a,i] * Phi_X[b,i]
+        self.kron_matrix = torch.einsum("an,bn->abn", self.Psi_U, self.Phi_X).reshape(
+            self.psi_dim * self.phi_dim, self.N
+        )
 
         # Solve for M and B
         if regressor == Regressor.RRR:
@@ -194,15 +198,11 @@ class KoopmanTensor:
         else:
             raise Exception("Did not pick a supported regression algorithm.")
 
-        # reshape M into tensor K
-        self.K = np.empty([self.phi_dim, self.phi_dim, self.psi_dim])
-        self.M = self.M.numpy()
-        for i in range(self.phi_dim):
-            self.K[i] = self.M[i].reshape((self.phi_dim, self.psi_dim), order="F")
-
-        # Cast to tensors
-        self.M = torch.tensor(self.M, dtype=torch.float64)
-        self.K = torch.tensor(self.K, dtype=torch.float64)
+        # reshape M into tensor K without leaving the device.
+        # The original used a per-row Fortran-order reshape of M[i] into (phi_dim, psi_dim);
+        # that equals the C-order reshape into (psi_dim, phi_dim) transposed.
+        self.M = self.M.contiguous()
+        self.K = self.M.reshape(self.phi_dim, self.psi_dim, self.phi_dim).transpose(-1, -2).contiguous()
 
     def K_(self, u):
         """

--- a/koopmanrl/koopman_tensor/torch_tensor.py
+++ b/koopmanrl/koopman_tensor/torch_tensor.py
@@ -364,5 +364,5 @@ def generate_koopman_tensor(
     kwargs = dict(phi=monomials(state_order), psi=monomials(action_order), regressor=Regressor(regressor))
     try:
         return KoopmanTensor(X, Y, U, dt=base.dt, **kwargs)
-    except Exception:
+    except AttributeError:
         return KoopmanTensor(X, Y, U, **kwargs)

--- a/koopmanrl/koopman_tensor/torch_tensor.py
+++ b/koopmanrl/koopman_tensor/torch_tensor.py
@@ -1,6 +1,10 @@
 from enum import Enum
 
+import gymnasium as gym
+import numpy as np
 import torch
+
+from koopmanrl.koopman_tensor.observables.torch_observables import monomials
 
 torch.set_default_dtype(torch.float64)
 
@@ -270,3 +274,95 @@ class KoopmanTensor:
         """
 
         return self.B.T @ self.phi_f(x, u)
+
+
+def generate_koopman_tensor(
+    env_id, seed, num_paths, num_steps_per_path, state_order, action_order, regressor,
+    device=None, dtype=torch.float64,
+):
+    """
+    Generate a KoopmanTensor from rollouts of the given Gymnasium environment.
+
+    When ``device`` is CUDA and the environment exposes ``f_batch`` / ``reset_batch``,
+    all paths are rolled out in parallel on the GPU.  Otherwise a sequential gym loop
+    is used (CPU fallback / parity reference).
+
+    Parameters
+    ----------
+    env_id : str
+        Gymnasium environment ID (e.g. "Lorenz-v0").
+    seed : int
+        RNG seed used for the environment, action sampling, and torch.
+    num_paths : int
+        Number of independent rollout paths.
+    num_steps_per_path : int
+        Number of environment steps per path.
+    state_order : int
+        Monomial order for the state observable phi.
+    action_order : int
+        Monomial order for the action observable psi.
+    regressor : str
+        Regression method: one of "ols", "sindy", "rrr", "ridge".
+    device : torch.device or None
+        Target device.  Defaults to CPU.
+    dtype : torch.dtype
+        Floating-point dtype.  Defaults to torch.float64.
+
+    Returns
+    -------
+    KoopmanTensor
+        A fitted KoopmanTensor with all internal tensors on ``device``.
+    """
+    import koopmanrl.environments  # noqa: F401 (register custom envs)
+
+    device = device or torch.device("cpu")
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    env = gym.make(env_id)
+    env.reset(seed=seed)
+    env.action_space.seed(seed)
+    base = env.unwrapped
+
+    state_dim = env.observation_space.shape[0]
+    action_dim = env.action_space.shape[0]
+
+    if device.type == "cuda" and hasattr(base, "f_batch"):
+        gen = torch.Generator(device=device).manual_seed(seed)
+        low = torch.as_tensor(env.action_space.low, device=device, dtype=dtype)
+        high = torch.as_tensor(env.action_space.high, device=device, dtype=dtype)
+        states = base.reset_batch(num_paths, device=device, dtype=dtype, generator=gen)
+        Xs, Ys, Us = [], [], []
+        for _ in range(num_steps_per_path):
+            actions = low + (high - low) * torch.rand(
+                num_paths, action_dim, device=device, dtype=dtype, generator=gen
+            )
+            next_states = base.f_batch(states, actions, generator=gen)
+            Xs.append(states)
+            Us.append(actions)
+            Ys.append(next_states)
+            states = next_states
+        X = torch.stack(Xs, dim=1).reshape(-1, state_dim).T
+        Y = torch.stack(Ys, dim=1).reshape(-1, state_dim).T
+        U = torch.stack(Us, dim=1).reshape(-1, action_dim).T
+    else:
+        X = torch.zeros((num_paths, num_steps_per_path, state_dim), dtype=dtype)
+        Y = torch.zeros_like(X)
+        U = torch.zeros((num_paths, num_steps_per_path, action_dim), dtype=dtype)
+        for p in range(num_paths):
+            state, _ = env.reset()
+            for s in range(num_steps_per_path):
+                X[p, s] = torch.as_tensor(state, dtype=dtype)
+                action = env.action_space.sample()
+                U[p, s] = torch.as_tensor(action, dtype=dtype)
+                state, _, _, _, _ = env.step(action)
+                Y[p, s] = torch.as_tensor(state, dtype=dtype)
+        n = num_paths * num_steps_per_path
+        X = X.reshape(n, state_dim).T.to(device)
+        Y = Y.reshape(n, state_dim).T.to(device)
+        U = U.reshape(n, action_dim).T.to(device)
+
+    kwargs = dict(phi=monomials(state_order), psi=monomials(action_order), regressor=Regressor(regressor))
+    try:
+        return KoopmanTensor(X, Y, U, dt=base.dt, **kwargs)
+    except Exception:
+        return KoopmanTensor(X, Y, U, **kwargs)

--- a/koopmanrl/opt_wrappers.py
+++ b/koopmanrl/opt_wrappers.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 
+from koopmanrl.koopman_tensor.torch_tensor import generate_koopman_tensor
 from koopmanrl.soft_actor_koopman_critic import (
     Actor,
     ReplayBuffer,
@@ -17,9 +18,8 @@ from koopmanrl.soft_actor_koopman_critic import (
 )
 from koopmanrl.soft_koopman_value_iteration import (
     DiscreteKoopmanValueIterationPolicy,
-    generate_koopman_tensor,
 )
-from koopmanrl.utils import make_env, vector_infos_to_list
+from koopmanrl.utils import make_env, resolve_device, resolve_dtype, vector_infos_to_list
 
 
 def skvi_tuning_wrapper(
@@ -39,6 +39,8 @@ def skvi_tuning_wrapper(
     state_order=2,
     action_order=2,
     regressor_type="ols",
+    cuda=False,
+    fp32=False,
 ):
     """
     Function-based version of the soft Koopman value iteration algorithm for hyperparameter tuning.
@@ -55,8 +57,8 @@ def skvi_tuning_wrapper(
     episodic_lengths_list = []
     steps_per_seconds_list = []
 
-    # CPU-only execution
-    device = torch.device("cpu")
+    device = resolve_device(cuda)
+    torch.set_default_dtype(resolve_dtype(fp32))
 
     # TRY NOT TO MODIFY: seeding
     random.seed(seed)
@@ -75,6 +77,8 @@ def skvi_tuning_wrapper(
         state_order=state_order,
         action_order=action_order,
         regressor=regressor_type,
+        device=device,
+        dtype=resolve_dtype(fp32),
     )
 
     try:
@@ -89,7 +93,7 @@ def skvi_tuning_wrapper(
             stop=envs.single_action_space.high,
             num=number_of_actions,
         )
-    ).T
+    ).T.to(device)
 
     # Construct value iteration policy
     value_iteration_policy = DiscreteKoopmanValueIterationPolicy(
@@ -103,6 +107,7 @@ def skvi_tuning_wrapper(
         learning_rate=learning_rate,
         seed=seed,
         dt=dt,
+        device=device,
     )
 
     # Use Koopman tensor training data to train policy
@@ -179,6 +184,8 @@ def sakc_tuning_wrapper(
     state_order=2,
     action_order=2,
     regressor_type="ols",
+    cuda=False,
+    fp32=False,
 ):
     """
     Function-based version of the soft Koopman actor-critic algorithm, built for hyperparameter tuning.
@@ -212,8 +219,8 @@ def sakc_tuning_wrapper(
     torch.manual_seed(seed)
     torch.backends.cudnn.deterministic = is_torch_deterministic
 
-    # Running everything on CPU
-    device = torch.device("cpu")
+    device = resolve_device(cuda)
+    torch.set_default_dtype(resolve_dtype(fp32))
 
     # env setup
     envs = gym.vector.SyncVectorEnv([make_env(env_id, seed, 0, to_capture_video, run_name)])
@@ -230,6 +237,8 @@ def sakc_tuning_wrapper(
         state_order=state_order,
         action_order=action_order,
         regressor=regressor_type,
+        device=device,
+        dtype=resolve_dtype(fp32),
     )
     vf = SoftKoopmanVNetwork(koopman_tensor).to(device)
     vf_target = SoftKoopmanVNetwork(koopman_tensor).to(device)
@@ -317,6 +326,15 @@ def sakc_tuning_wrapper(
         if global_step > learning_starts:
             # Sample from replay buffer
             data = rb.sample(batch_size)
+            # SB3 ReplayBuffer always stores float32; cast to the network dtype (float64 by default).
+            net_dtype = next(actor.parameters()).dtype
+            data = data._replace(
+                observations=data.observations.to(net_dtype),
+                actions=data.actions.to(net_dtype),
+                next_observations=data.next_observations.to(net_dtype),
+                rewards=data.rewards.to(net_dtype),
+                dones=data.dones.to(net_dtype),
+            )
 
             # E_s_t~D [ 1/2 ( V_psi( s_t ) - E_a_t~pi_phi [ Q_theta( s_t, a_t ) - log pi_phi( a_t | s_t ) ] )^2 ]
             vf_values = vf(data.observations).view(-1)

--- a/koopmanrl/opt_wrappers.py
+++ b/koopmanrl/opt_wrappers.py
@@ -19,7 +19,12 @@ from koopmanrl.soft_actor_koopman_critic import (
 from koopmanrl.soft_koopman_value_iteration import (
     DiscreteKoopmanValueIterationPolicy,
 )
-from koopmanrl.utils import make_env, resolve_device, resolve_dtype, vector_infos_to_list
+from koopmanrl.utils import (
+    make_env,
+    resolve_device,
+    resolve_dtype,
+    vector_infos_to_list,
+)
 
 
 def skvi_tuning_wrapper(

--- a/koopmanrl/opt_wrappers.py
+++ b/koopmanrl/opt_wrappers.py
@@ -98,7 +98,7 @@ def skvi_tuning_wrapper(
             stop=envs.single_action_space.high,
             num=number_of_actions,
         )
-    ).T.to(device)
+    ).T.to(device=device, dtype=resolve_dtype(fp32))
 
     # Construct value iteration policy
     value_iteration_policy = DiscreteKoopmanValueIterationPolicy(

--- a/koopmanrl/sac_continuous_action.py
+++ b/koopmanrl/sac_continuous_action.py
@@ -116,8 +116,7 @@ def main():
     torch.manual_seed(sampled_seed)
     torch.backends.cudnn.deterministic = args.torch_deterministic
 
-    # Running everything on CPU
-    device = torch.device("cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
     envs = gym.vector.SyncVectorEnv([make_env(args.env_id, sampled_seed, 0, args.capture_video, run_name)])
@@ -206,6 +205,15 @@ def main():
         # ALGO LOGIC: training.
         if global_step > args.learning_starts:
             data = rb.sample(args.batch_size)
+            # SB3 ReplayBuffer always stores float32; cast to the network dtype (float64 by default).
+            net_dtype = next(actor.parameters()).dtype
+            data = data._replace(
+                observations=data.observations.to(dtype=net_dtype),
+                actions=data.actions.to(dtype=net_dtype),
+                next_observations=data.next_observations.to(dtype=net_dtype),
+                rewards=data.rewards.to(dtype=net_dtype),
+                dones=data.dones.to(dtype=net_dtype),
+            )
             with torch.no_grad():
                 next_state_actions, next_state_log_pi, _ = actor.get_action(data.next_observations)
                 qf1_next_target = qf1_target(data.next_observations, next_state_actions)

--- a/koopmanrl/soft_actor_koopman_critic.py
+++ b/koopmanrl/soft_actor_koopman_critic.py
@@ -165,7 +165,7 @@ class Actor(nn.Module):
         # action rescaling
         high_action = env.action_space.high
         low_action = env.action_space.low
-        dtype = torch.float64
+        dtype = torch.get_default_dtype()
         action_scale = torch.tensor((high_action - low_action) / 2.0, dtype=dtype)
         action_bias = torch.tensor((high_action + low_action) / 2.0, dtype=dtype)
         self.register_buffer("action_scale", action_scale)

--- a/koopmanrl/soft_actor_koopman_critic.py
+++ b/koopmanrl/soft_actor_koopman_critic.py
@@ -16,7 +16,10 @@ from torch.utils.tensorboard import SummaryWriter
 
 from koopmanrl.environments import DoubleWell, FluidFlow, LinearSystem, Lorenz
 from koopmanrl.koopman_observables import monomials
-from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor, generate_koopman_tensor
+from koopmanrl.koopman_tensor.torch_tensor import (
+    KoopmanTensor,
+    generate_koopman_tensor,
+)
 from koopmanrl.utils import (
     create_folder,
     load_and_apply_config,

--- a/koopmanrl/soft_actor_koopman_critic.py
+++ b/koopmanrl/soft_actor_koopman_critic.py
@@ -1,7 +1,6 @@
 import os
 import random
 import time
-from enum import Enum
 from typing import Optional
 
 import gym as legacy_gym
@@ -17,14 +16,15 @@ from torch.utils.tensorboard import SummaryWriter
 
 from koopmanrl.environments import DoubleWell, FluidFlow, LinearSystem, Lorenz
 from koopmanrl.koopman_observables import monomials
+from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor, generate_koopman_tensor
 from koopmanrl.utils import (
     create_folder,
     load_and_apply_config,
     make_env,
+    resolve_device,
+    resolve_dtype,
     vector_infos_to_list,
 )
-
-torch.set_default_dtype(torch.float64)  # Might not strictly be necessary outside of the Koopman calculation
 
 # ---------------------------------------------------------------------------
 # JSON config loading
@@ -88,333 +88,7 @@ class ArgumentParser(Tap):
     action_order: Optional[int] = None  # action monomial order; loaded from config if not set (default: 2)
     regressor: str = "ols"  # Which regressor to use to build the Koopman tensor (default: 'ols')
     config_file: Optional[str] = None  # path to a JSON config file; CLI flags override file values
-
-
-def checkMatrixRank(X, name):
-    rank = torch.linalg.matrix_rank(X)
-    print(f"{name} matrix rank: {rank}")
-    if rank != X.shape[0]:
-        # raise ValueError(f"{name} matrix is not full rank ({rank} / {X.shape[0]})")
-        pass
-
-
-def checkConditionNumber(X, name, threshold=200):
-    cond_num = torch.linalg.cond(X)
-    print(f"Condition number of {name}: {cond_num}")
-    if cond_num > threshold:
-        # raise ValueError(f"Condition number of {name} is too large ({cond_num} > {threshold})")
-        pass
-
-
-def ols(X, Y):
-    return torch.linalg.lstsq(X, Y, rcond=None).solution
-
-
-def OLS(X, Y):
-    return ols(X, Y)
-
-
-def SINDy(Theta, dXdt, lamb=0.05):
-    d = dXdt.shape[1]
-    Xi = torch.linalg.lstsq(Theta, dXdt, rcond=None).solution  # Initial guess: Least-squares
-
-    for _ in range(10):
-        smallinds = torch.abs(Xi) < lamb  # Find small coefficients
-        Xi[smallinds] = 0  # and threshold
-        for ind in range(d):  # n is state dimension
-            biginds = smallinds[:, ind] == 0
-            # Regress dynamics onto remaining terms to find sparse Xi
-            Xi[biginds, ind] = torch.linalg.lstsq(Theta[:, biginds], dXdt[:, ind].unsqueeze(0).T, rcond=None).solution[
-                :, 0
-            ]
-
-    L = Xi
-    return L
-
-
-def rrr(X, Y, rank=8):
-    B_ols = ols(X, Y)  # if infeasible use GD (numpy CG)
-    U, S, V = torch.linalg.svd(Y.T @ X @ B_ols)
-    W = V[0:rank].T
-
-    B_rr = B_ols @ W @ W.T
-    L = B_rr  # .T
-    return L
-
-
-def RRR(X, Y, rank=8):
-    return rrr(X, Y, rank)
-
-
-def ridgeRegression(X, y, lamb=0.05):
-    return torch.linalg.inv(X.T @ X + (lamb * torch.eye(X.shape[1]))) @ X.T @ y
-
-
-class Regressor(str, Enum):
-    OLS = "ols"
-    SINDy = "sindy"
-    RRR = "rrr"
-    RIDGE = "ridge"
-
-
-class KoopmanTensor:
-    def __init__(
-        self,
-        X,
-        Y,
-        U,
-        phi,
-        psi,
-        regressor=Regressor.OLS,
-        rank=8,
-        is_generator=False,
-        dt=0.01,
-    ):
-        """
-        Create an instance of the KoopmanTensor class.
-
-        Parameters
-        ----------
-        X : array_like
-            States dataset used for training.
-        Y : array_like
-            Single-step forward states dataset used for training.
-        U : array_like
-            Actions dataset used for training.
-        phi : callable
-            Dictionary space representing the states.
-        psi : callable
-            Dictionary space representing the actions.
-        regressor : {'ols', 'sindy', 'rrr'}, optional
-            String indicating the regression method to use. Default is 'ols'.
-        p_inv : bool, optional
-            Boolean indicating whether to use pseudo-inverse instead of regular inverse. Default is True.
-        rank : int, optional
-            Rank of the Koopman tensor when applying reduced rank regression. Default is 8.
-        is_generator : bool, optional
-            Boolean indicating whether the model is a Koopman generator tensor. Default is False.
-        dt : float, optional
-            The time step of the system. Default is 0.01.
-
-        Returns
-        -------
-        KoopmanTensor
-            An instance of the KoopmanTensor class.
-        """
-
-        # Save datasets
-        self.X = X
-        self.Y = Y
-        self.U = U
-
-        # Extract dictionary/observable functions
-        self.phi = phi
-        self.psi = psi
-
-        # Get number of data points
-        self.N = self.X.shape[1]
-
-        # Construct Phi and Psi matrices
-        self.Phi_X = self.phi(X)
-        self.Phi_Y = self.phi(Y)
-        self.Psi_U = self.psi(U)
-
-        # Get dimensions
-        self.x_dim = self.X.shape[0]
-        self.u_dim = self.U.shape[0]
-        self.phi_dim = self.Phi_X.shape[0]
-        self.psi_dim = self.Psi_U.shape[0]
-        self.x_column_dim = (self.x_dim, 1)
-        self.u_column_dim = (self.u_dim, 1)
-        self.phi_column_dim = (self.phi_dim, 1)
-
-        # Update regression matrices if dealing with Koopman generator
-        if is_generator:
-            # Save delta time
-            self.dt = dt
-
-            # Update regression target
-            finite_differences = self.Y - self.X  # (self.x_dim, self.N)
-            phi_derivative = self.phi.diff(self.X)  # (self.phi_dim, self.x_dim, self.N)
-            phi_double_derivative = self.phi.ddiff(self.X)  # (self.phi_dim, self.x_dim, self.x_dim, self.N)
-            self.regression_Y = torch.einsum("os,pos->ps", finite_differences / self.dt, phi_derivative)
-            self.regression_Y += torch.einsum(
-                "ot,pots->ps",
-                0.5 * (finite_differences @ finite_differences.T) / self.dt,  # (state_dim, state_dim)
-                phi_double_derivative,
-            )
-        else:
-            # Set regression target to phi(Y)
-            self.regression_Y = self.Phi_Y
-
-        # Make sure data is full rank
-        checkMatrixRank(self.Phi_X, "Phi_X")
-        checkMatrixRank(self.regression_Y, "dPhi_Y" if is_generator else "Phi_Y")
-        checkMatrixRank(self.Psi_U, "Psi_U")
-        print("\n")
-
-        # Make sure condition numbers are small
-        checkConditionNumber(self.Phi_X, "Phi_X")
-        checkConditionNumber(self.regression_Y, "dPhi_Y" if is_generator else "Phi_Y")
-        checkConditionNumber(self.Psi_U, "Psi_U")
-        print("\n")
-
-        # Build matrix of kronecker products between u_i and x_i for all 0 <= i <= N
-        self.kron_matrix = torch.empty([self.psi_dim * self.phi_dim, self.N])
-        for i in range(self.N):
-            self.kron_matrix[:, i] = torch.kron(self.Psi_U[:, i], self.Phi_X[:, i])
-
-        # Solve for M and B
-        if regressor == Regressor.RRR:
-            self.M = rrr(self.kron_matrix.T, self.regression_Y.T, rank).T
-            self.B = rrr(self.Phi_X.T, self.X.T, rank)
-        elif regressor == Regressor.SINDy:
-            self.M = SINDy(self.kron_matrix.T, self.regression_Y.T).T
-            self.B = SINDy(self.Phi_X.T, self.X.T)
-        elif regressor == Regressor.OLS:
-            self.M = ols(self.kron_matrix.T, self.regression_Y.T).T
-            self.B = ols(self.Phi_X.T, self.X.T)
-        elif regressor == Regressor.RIDGE:
-            self.M = ridgeRegression(self.kron_matrix.T, self.regression_Y.T).T
-            self.B = ridgeRegression(self.Phi_X.T, self.X.T)
-        else:
-            raise Exception("Did not pick a supported regression algorithm.")
-
-        # reshape M into tensor K
-        self.K = np.empty([self.phi_dim, self.phi_dim, self.psi_dim])
-        self.M = self.M.numpy()
-        for i in range(self.phi_dim):
-            self.K[i] = self.M[i].reshape((self.phi_dim, self.psi_dim), order="F")
-
-        # Cast to tensors
-        self.M = torch.tensor(self.M, dtype=torch.float64)
-        self.K = torch.tensor(self.K, dtype=torch.float64)
-
-    def K_(self, u):
-        """
-        Compute the Koopman operator associated with a given action.
-
-        Parameters
-        ----------
-        u : array_like
-            Action as a column vector or matrix of column vectors for which the Koopman operator is computed.
-
-        Returns
-        -------
-        ndarray
-            Koopman operator corresponding to the given action.
-        """
-
-        K_u = torch.einsum("ijz,zk->kij", self.K, self.psi(u))
-
-        if K_u.shape[0] == 1:
-            return K_u[0]
-
-        return K_u
-
-    def phi_f(self, x, u):
-        """
-        Apply the Koopman tensor to push forward phi(x) x psi(u) to phi(x').
-
-        Parameters
-        ----------
-        x : array_like
-            State column vector(s).
-        u : array_like
-            Action column vector(s).
-
-        Returns
-        -------
-        ndarray
-            Transformed phi(x') column vector(s).
-        """
-
-        K_us = self.K_(u)  # (batch_size, phi_dim, phi_dim)
-        phi_x = self.phi(x)  # (phi_dim, batch_size)
-
-        if len(K_us.shape) == 2:
-            return K_us @ phi_x
-
-        phi_x_primes = (K_us @ phi_x.T.unsqueeze(-1)).squeeze(-1)
-        return phi_x_primes.T
-
-    def f(self, x, u):
-        """
-        Utilize the Koopman tensor to approximate the true dynamics f(x, u) and predict x'.
-
-        Parameters
-        ----------
-        x : array_like
-            State column vector(s).
-        u : array_like
-            Action column vector(s).
-
-        Returns
-        -------
-        ndarray
-            Predicted state column vector(s).
-        """
-
-        return self.B.T @ self.phi_f(x, u)
-
-
-def generate_koopman_tensor(env_id, seed, num_paths, num_steps_per_path, state_order, action_order, regressor):
-    # Set seeds and create environment
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    env = gym.make(env_id)
-    env.reset(seed=seed)
-    env.action_space.seed(seed)
-    env.observation_space.seed(seed)
-
-    # Collect data
-    state_dim = env.observation_space.shape
-    state_dim = 1 if len(state_dim) == 0 else state_dim[0]
-    action_dim = env.action_space.shape
-    action_dim = 1 if len(action_dim) == 0 else action_dim[0]
-    X = torch.zeros((num_paths, num_steps_per_path, state_dim))
-    Y = torch.zeros_like(X)
-    U = torch.zeros((num_paths, num_steps_per_path, action_dim))
-
-    for path_num in range(num_paths):
-        state, _ = env.reset()
-        for step_num in range(num_steps_per_path):
-            X[path_num, step_num] = torch.tensor(state)
-            action = env.action_space.sample()
-            U[path_num, step_num] = torch.tensor(action)
-
-            state, _, _, _, _ = env.step(action)
-            Y[path_num, step_num] = torch.tensor(state)
-
-    # Reshape data into matrices
-    total_num_datapoints = num_paths * num_steps_per_path
-    X = X.reshape(total_num_datapoints, state_dim).T
-    Y = Y.reshape(total_num_datapoints, state_dim).T
-    U = U.reshape(total_num_datapoints, action_dim).T
-
-    # Construct the Koopman tensor
-    try:
-        path_based_tensor = KoopmanTensor(
-            X,
-            Y,
-            U,
-            phi=monomials(state_order),
-            psi=monomials(action_order),
-            regressor=Regressor(regressor),
-            dt=env.dt,
-        )
-    except:  # noqa: E722
-        # Assume the error was because there is no dt for LinearSystem
-        path_based_tensor = KoopmanTensor(
-            X,
-            Y,
-            U,
-            phi=monomials(state_order),
-            psi=monomials(action_order),
-            regressor=Regressor(regressor),
-        )
-
-    return path_based_tensor
+    fp32: bool = False  # use float32 instead of float64 (default: False)
 
 
 # ALGO LOGIC: initialize agent here:
@@ -467,7 +141,8 @@ class SoftKoopmanVNetwork(nn.Module):
     def forward(self, state):
         """Linear in the phi(x)s"""
 
-        phi_xs = self.koopman_tensor.phi(state.T).T
+        dtype = next(self.parameters()).dtype
+        phi_xs = self.koopman_tensor.phi(state.to(dtype=dtype).T).T
 
         output = self.linear(phi_xs)
 
@@ -541,8 +216,8 @@ def main():
     torch.manual_seed(args.seed)
     torch.backends.cudnn.deterministic = args.torch_deterministic
 
-    # Running everything on CPU
-    device = torch.device("cpu")
+    device = resolve_device(args.cuda)
+    torch.set_default_dtype(resolve_dtype(args.fp32))
 
     # env setup
     envs = gym.vector.SyncVectorEnv([make_env(args.env_id, args.seed, 0, args.capture_video, run_name)])
@@ -559,6 +234,8 @@ def main():
         state_order=args.state_order,
         action_order=args.action_order,
         regressor=args.regressor,
+        device=device,
+        dtype=resolve_dtype(args.fp32),
     )
     vf = SoftKoopmanVNetwork(koopman_tensor).to(device)
     vf_target = SoftKoopmanVNetwork(koopman_tensor).to(device)
@@ -645,6 +322,15 @@ def main():
         if global_step > args.learning_starts:
             # Sample from replay buffer
             data = rb.sample(args.batch_size)
+            # SB3 ReplayBuffer always stores float32; cast to the network dtype (float64 by default).
+            net_dtype = next(actor.parameters()).dtype
+            data = data._replace(
+                observations=data.observations.to(dtype=net_dtype),
+                next_observations=data.next_observations.to(dtype=net_dtype),
+                actions=data.actions.to(dtype=net_dtype),
+                rewards=data.rewards.to(dtype=net_dtype),
+                dones=data.dones.to(dtype=net_dtype),
+            )
 
             # E_s_t~D [ 1/2 ( V_psi( s_t ) - E_a_t~pi_phi [ Q_theta( s_t, a_t ) - log pi_phi( a_t | s_t ) ] )^2 ]
             vf_values = vf(data.observations).view(-1)

--- a/koopmanrl/soft_koopman_value_iteration.py
+++ b/koopmanrl/soft_koopman_value_iteration.py
@@ -604,7 +604,7 @@ def main():
             stop=envs.single_action_space.high,
             num=args.num_actions,
         )
-    ).T.to(device)
+    ).T.to(device=device, dtype=resolve_dtype(args.fp32))
 
     # Construct value iteration policy
     value_iteration_policy = DiscreteKoopmanValueIterationPolicy(

--- a/koopmanrl/soft_koopman_value_iteration.py
+++ b/koopmanrl/soft_koopman_value_iteration.py
@@ -1,7 +1,6 @@
 import os
 import random
 import time
-from enum import Enum
 from typing import Optional
 
 import gymnasium as gym
@@ -12,7 +11,14 @@ from torch.utils.tensorboard import SummaryWriter
 
 from koopmanrl.environments import DoubleWell, FluidFlow, LinearSystem, Lorenz
 from koopmanrl.koopman_observables import monomials
-from koopmanrl.utils import create_folder, load_and_apply_config, make_env
+from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor, generate_koopman_tensor
+from koopmanrl.utils import (
+    create_folder,
+    load_and_apply_config,
+    make_env,
+    resolve_device,
+    resolve_dtype,
+)
 
 torch.set_default_dtype(torch.float64)
 delta = torch.finfo(torch.float64).eps  # 2.220446049250313e-16
@@ -54,6 +60,7 @@ class ArgumentParser(Tap):
     seed: Optional[int] = None  # seed of the experiment; loaded from config if not set (default: 1)
     torch_deterministic: bool = True  # if toggled, `torch.backends.cudnn.deterministic=False` (default: True)
     cuda: bool = False  # if toggled, cuda will be enabled by default (default: True)
+    fp32: bool = False  # use float32 instead of float64 (default: False)
     env_id: Optional[str] = None  # id of the environment; loaded from config if not set (default: LinearSystem-v0)
     total_timesteps: Optional[int] = None  # total timesteps; loaded from config if not set (default: 50000)
     gamma: float = 0.99  # the discount factor gamma (default: 0.99)
@@ -71,333 +78,6 @@ class ArgumentParser(Tap):
     config_file: Optional[str] = None  # path to a JSON config file; CLI flags override file values
 
 
-def checkMatrixRank(X, name):
-    rank = torch.linalg.matrix_rank(X)
-    print(f"{name} matrix rank: {rank}")
-    if rank != X.shape[0]:
-        # raise ValueError(f"{name} matrix is not full rank ({rank} / {X.shape[0]})")
-        pass
-
-
-def checkConditionNumber(X, name, threshold=200):
-    cond_num = torch.linalg.cond(X)
-    print(f"Condition number of {name}: {cond_num}")
-    if cond_num > threshold:
-        # raise ValueError(f"Condition number of {name} is too large ({cond_num} > {threshold})")
-        pass
-
-
-def ols(X, Y):
-    return torch.linalg.lstsq(X, Y, rcond=None).solution
-
-
-def OLS(X, Y):
-    return ols(X, Y)
-
-
-def SINDy(Theta, dXdt, lamb=0.05):
-    d = dXdt.shape[1]
-    Xi = torch.linalg.lstsq(Theta, dXdt, rcond=None).solution  # Initial guess: Least-squares
-
-    for _ in range(10):
-        smallinds = torch.abs(Xi) < lamb  # Find small coefficients
-        Xi[smallinds] = 0  # and threshold
-        for ind in range(d):  # n is state dimension
-            biginds = smallinds[:, ind] == 0
-            # Regress dynamics onto remaining terms to find sparse Xi
-            Xi[biginds, ind] = torch.linalg.lstsq(Theta[:, biginds], dXdt[:, ind].unsqueeze(0).T, rcond=None).solution[
-                :, 0
-            ]
-
-    L = Xi
-    return L
-
-
-def rrr(X, Y, rank=8):
-    B_ols = ols(X, Y)  # if infeasible use GD (numpy CG)
-    U, S, V = torch.linalg.svd(Y.T @ X @ B_ols)
-    W = V[0:rank].T
-
-    B_rr = B_ols @ W @ W.T
-    L = B_rr  # .T
-    return L
-
-
-def RRR(X, Y, rank=8):
-    return rrr(X, Y, rank)
-
-
-def ridgeRegression(X, y, lamb=0.05):
-    return torch.linalg.inv(X.T @ X + (lamb * torch.eye(X.shape[1]))) @ X.T @ y
-
-
-class Regressor(str, Enum):
-    OLS = "ols"
-    SINDy = "sindy"
-    RRR = "rrr"
-    RIDGE = "ridge"
-
-
-class KoopmanTensor:
-    def __init__(
-        self,
-        X,
-        Y,
-        U,
-        phi,
-        psi,
-        regressor=Regressor.OLS,
-        rank=8,
-        is_generator=False,
-        dt=0.01,
-    ):
-        """
-        Create an instance of the KoopmanTensor class.
-
-        Parameters
-        ----------
-        X : array_like
-            States dataset used for training.
-        Y : array_like
-            Single-step forward states dataset used for training.
-        U : array_like
-            Actions dataset used for training.
-        phi : callable
-            Dictionary space representing the states.
-        psi : callable
-            Dictionary space representing the actions.
-        regressor : {'ols', 'sindy', 'rrr'}, optional
-            String indicating the regression method to use. Default is 'ols'.
-        p_inv : bool, optional
-            Boolean indicating whether to use pseudo-inverse instead of regular inverse. Default is True.
-        rank : int, optional
-            Rank of the Koopman tensor when applying reduced rank regression. Default is 8.
-        is_generator : bool, optional
-            Boolean indicating whether the model is a Koopman generator tensor. Default is False.
-        dt : float, optional
-            The time step of the system. Default is 0.01.
-
-        Returns
-        -------
-        KoopmanTensor
-            An instance of the KoopmanTensor class.
-        """
-
-        # Save datasets
-        self.X = X
-        self.Y = Y
-        self.U = U
-
-        # Extract dictionary/observable functions
-        self.phi = phi
-        self.psi = psi
-
-        # Get number of data points
-        self.N = self.X.shape[1]
-
-        # Construct Phi and Psi matrices
-        self.Phi_X = self.phi(X)
-        self.Phi_Y = self.phi(Y)
-        self.Psi_U = self.psi(U)
-
-        # Get dimensions
-        self.x_dim = self.X.shape[0]
-        self.u_dim = self.U.shape[0]
-        self.phi_dim = self.Phi_X.shape[0]
-        self.psi_dim = self.Psi_U.shape[0]
-        self.x_column_dim = (self.x_dim, 1)
-        self.u_column_dim = (self.u_dim, 1)
-        self.phi_column_dim = (self.phi_dim, 1)
-
-        # Update regression matrices if dealing with Koopman generator
-        if is_generator:
-            # Save delta time
-            self.dt = dt
-
-            # Update regression target
-            finite_differences = self.Y - self.X  # (self.x_dim, self.N)
-            phi_derivative = self.phi.diff(self.X)  # (self.phi_dim, self.x_dim, self.N)
-            phi_double_derivative = self.phi.ddiff(self.X)  # (self.phi_dim, self.x_dim, self.x_dim, self.N)
-            self.regression_Y = torch.einsum("os,pos->ps", finite_differences / self.dt, phi_derivative)
-            self.regression_Y += torch.einsum(
-                "ot,pots->ps",
-                0.5 * (finite_differences @ finite_differences.T) / self.dt,  # (state_dim, state_dim)
-                phi_double_derivative,
-            )
-        else:
-            # Set regression target to phi(Y)
-            self.regression_Y = self.Phi_Y
-
-        # Make sure data is full rank
-        checkMatrixRank(self.Phi_X, "Phi_X")
-        checkMatrixRank(self.regression_Y, "dPhi_Y" if is_generator else "Phi_Y")
-        checkMatrixRank(self.Psi_U, "Psi_U")
-        print("\n")
-
-        # Make sure condition numbers are small
-        checkConditionNumber(self.Phi_X, "Phi_X")
-        checkConditionNumber(self.regression_Y, "dPhi_Y" if is_generator else "Phi_Y")
-        checkConditionNumber(self.Psi_U, "Psi_U")
-        print("\n")
-
-        # Build matrix of kronecker products between u_i and x_i for all 0 <= i <= N
-        self.kron_matrix = torch.empty([self.psi_dim * self.phi_dim, self.N])
-        for i in range(self.N):
-            self.kron_matrix[:, i] = torch.kron(self.Psi_U[:, i], self.Phi_X[:, i])
-
-        # Solve for M and B
-        if regressor == Regressor.RRR:
-            self.M = rrr(self.kron_matrix.T, self.regression_Y.T, rank).T
-            self.B = rrr(self.Phi_X.T, self.X.T, rank)
-        elif regressor == Regressor.SINDy:
-            self.M = SINDy(self.kron_matrix.T, self.regression_Y.T).T
-            self.B = SINDy(self.Phi_X.T, self.X.T)
-        elif regressor == Regressor.OLS:
-            self.M = ols(self.kron_matrix.T, self.regression_Y.T).T
-            self.B = ols(self.Phi_X.T, self.X.T)
-        elif regressor == Regressor.RIDGE:
-            self.M = ridgeRegression(self.kron_matrix.T, self.regression_Y.T).T
-            self.B = ridgeRegression(self.Phi_X.T, self.X.T)
-        else:
-            raise Exception("Did not pick a supported regression algorithm.")
-
-        # reshape M into tensor K
-        self.K = np.empty([self.phi_dim, self.phi_dim, self.psi_dim])
-        self.M = self.M.numpy()
-        for i in range(self.phi_dim):
-            self.K[i] = self.M[i].reshape((self.phi_dim, self.psi_dim), order="F")
-
-        # Cast to tensors
-        self.M = torch.tensor(self.M, dtype=torch.float64)
-        self.K = torch.tensor(self.K, dtype=torch.float64)
-
-    def K_(self, u):
-        """
-        Compute the Koopman operator associated with a given action.
-
-        Parameters
-        ----------
-        u : array_like
-            Action as a column vector or matrix of column vectors for which the Koopman operator is computed.
-
-        Returns
-        -------
-        ndarray
-            Koopman operator corresponding to the given action.
-        """
-
-        K_u = torch.einsum("ijz,zk->kij", self.K, self.psi(u))
-
-        if K_u.shape[0] == 1:
-            return K_u[0]
-
-        return K_u
-
-    def phi_f(self, x, u):
-        """
-        Apply the Koopman tensor to push forward phi(x) x psi(u) to phi(x').
-
-        Parameters
-        ----------
-        x : array_like
-            State column vector(s).
-        u : array_like
-            Action column vector(s).
-
-        Returns
-        -------
-        ndarray
-            Transformed phi(x') column vector(s).
-        """
-
-        K_us = self.K_(u)  # (batch_size, phi_dim, phi_dim)
-        phi_x = self.phi(x)  # (phi_dim, batch_size)
-
-        if len(K_us.shape) == 2:
-            return K_us @ phi_x
-
-        phi_x_primes = (K_us @ phi_x.T.unsqueeze(-1)).squeeze(-1)
-        return phi_x_primes.T
-
-    def f(self, x, u):
-        """
-        Utilize the Koopman tensor to approximate the true dynamics f(x, u) and predict x'.
-
-        Parameters
-        ----------
-        x : array_like
-            State column vector(s).
-        u : array_like
-            Action column vector(s).
-
-        Returns
-        -------
-        ndarray
-            Predicted state column vector(s).
-        """
-
-        return self.B.T @ self.phi_f(x, u)
-
-
-def generate_koopman_tensor(env_id, seed, num_paths, num_steps_per_path, state_order, action_order, regressor):
-    # Set seeds and create environment
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    env = gym.make(env_id)
-    env.reset(seed=seed)
-    env.action_space.seed(seed)
-    env.observation_space.seed(seed)
-
-    # Collect data
-    state_dim = env.observation_space.shape
-    state_dim = 1 if len(state_dim) == 0 else state_dim[0]
-    action_dim = env.action_space.shape
-    action_dim = 1 if len(action_dim) == 0 else action_dim[0]
-    X = torch.zeros((num_paths, num_steps_per_path, state_dim))
-    Y = torch.zeros_like(X)
-    U = torch.zeros((num_paths, num_steps_per_path, action_dim))
-
-    for path_num in range(num_paths):
-        state, _ = env.reset()
-        for step_num in range(num_steps_per_path):
-            X[path_num, step_num] = torch.tensor(state)
-            action = env.action_space.sample()
-            U[path_num, step_num] = torch.tensor(action)
-
-            state, _, _, _, _ = env.step(action)
-            Y[path_num, step_num] = torch.tensor(state)
-
-    # Reshape data into matrices
-    total_num_datapoints = num_paths * num_steps_per_path
-    X = X.reshape(total_num_datapoints, state_dim).T
-    Y = Y.reshape(total_num_datapoints, state_dim).T
-    U = U.reshape(total_num_datapoints, action_dim).T
-
-    # Construct the Koopman tensor
-    try:
-        path_based_tensor = KoopmanTensor(
-            X,
-            Y,
-            U,
-            phi=monomials(state_order),
-            psi=monomials(action_order),
-            regressor=Regressor(regressor),
-            dt=env.dt,
-        )
-    except:  # noqa: E722
-        # Assume the error was because there is no dt for LinearSystem
-        path_based_tensor = KoopmanTensor(
-            X,
-            Y,
-            U,
-            phi=monomials(state_order),
-            psi=monomials(action_order),
-            regressor=Regressor(regressor),
-        )
-
-    return path_based_tensor
-
-
 class DiscreteKoopmanValueIterationPolicy:
     def __init__(
         self,
@@ -411,6 +91,7 @@ class DiscreteKoopmanValueIterationPolicy:
         use_ols=True,
         learning_rate=0.003,
         dt=None,
+        device=None,
     ):
         """
         Initialize DiscreteKoopmanValueIterationPolicy.
@@ -468,14 +149,17 @@ class DiscreteKoopmanValueIterationPolicy:
         self.dt = dt
         if self.dt is None:
             self.dt = 1.0
+        self.device = device if device is not None else torch.device("cpu")
 
         self.discount_factor = self.gamma**self.dt
 
         # Handle model initialization
         if self.use_ols:
-            self.value_function_weights = torch.zeros((self.dynamics_model.phi_dim, 1))
+            self.value_function_weights = torch.zeros((self.dynamics_model.phi_dim, 1), device=self.device)
         else:
-            self.value_function_weights = torch.zeros((self.dynamics_model.phi_dim, 1), requires_grad=True)
+            self.value_function_weights = torch.zeros(
+                (self.dynamics_model.phi_dim, 1), requires_grad=True, device=self.device
+            )
             self.value_function_optimizer = torch.optim.Adam([self.value_function_weights], lr=self.learning_rate)
 
     def load_model(
@@ -513,20 +197,16 @@ class DiscreteKoopmanValueIterationPolicy:
         """
 
         # Compute phi(x) for each x
-        phi_xs = self.dynamics_model.phi(xs.T)  # (dim_phi, batch_size)
+        phi_xs = self.dynamics_model.phi(xs.T)  # (phi_dim, batch)
 
-        # Compute phi(x') for all ( phi(x), action ) pairs and compute V(x')s
-        K_us = self.dynamics_model.K_(self.all_actions)  # (all_actions.shape[1], phi_dim, phi_dim)
-        phi_x_prime_batch = torch.zeros([self.all_actions.shape[1], self.dynamics_model.phi_dim, xs.shape[1]])
-        V_x_prime_batch = torch.zeros([self.all_actions.shape[1], xs.shape[1]])
-        for action_index in range(K_us.shape[0]):
-            phi_x_prime_hat_batch = K_us[action_index] @ phi_xs  # (dim_phi, batch_size)
-            phi_x_prime_batch[action_index] = phi_x_prime_hat_batch
-            V_x_prime_batch[action_index] = self.V_phi_x(phi_x_prime_batch[action_index])  # (1, batch_size)
-            #! Something is wrong here with value_function_continuous_action
+        # Compute phi(x') for all ( phi(x), action ) pairs and compute V(x')s (vectorized)
+        K_us = self.dynamics_model.K_(self.all_actions)  # (num_actions, phi_dim, phi_dim)
+        phi_x_prime_batch = torch.einsum("aij,jb->aib", K_us, phi_xs)  # (num_actions, phi_dim, batch)
+        w = self.value_function_weights.squeeze(-1)  # (phi_dim,)
+        V_x_prime_batch = torch.einsum("p,apb->ab", w, phi_x_prime_batch)  # (num_actions, batch)
 
         # Get costs indexed by the action and the state
-        costs = torch.Tensor(self.cost(xs, self.all_actions.T))  # (all_actions.shape[1], batch_size)
+        costs = self.cost(xs, self.all_actions.T)  # (num_actions, batch)
 
         # Compute policy distribution
         inner_pi_us_values = -(costs + self.discount_factor * V_x_prime_batch)  # (all_actions.shape[1], xs.shape[1])
@@ -592,7 +272,9 @@ class DiscreteKoopmanValueIterationPolicy:
         """
 
         # Get random sample of xs and phi(x)s from dataset
-        x_batch_indices = torch.from_numpy(np.random.choice(self.dynamics_model.X.shape[1], batch_size, replace=False))
+        x_batch_indices = torch.from_numpy(
+            np.random.choice(self.dynamics_model.X.shape[1], batch_size, replace=False)
+        ).to(self.device)
         x_batch = self.dynamics_model.X[:, x_batch_indices.long()]  # (X.shape[0], batch_size)
         phi_x_batch = self.dynamics_model.Phi_X[:, x_batch_indices.long()]  # (dim_phi, batch_size)
 
@@ -600,18 +282,13 @@ class DiscreteKoopmanValueIterationPolicy:
         V_xs = self.V_phi_x(phi_x_batch)  # (1, batch_size)
 
         # Get costs indexed by the action and the state
-        costs = torch.Tensor(self.cost(x_batch.T, self.all_actions.T))  # (all_actions.shape[1], batch_size)
+        costs = self.cost(x_batch.T, self.all_actions.T)  # (num_actions, batch)
 
-        # Compute phi(x') for all ( phi(x), action ) pairs and compute V(x')s
-        K_us = self.dynamics_model.K_(self.all_actions)  # (all_actions.shape[1], phi_dim, phi_dim)
-        phi_x_prime_batch = torch.zeros([self.all_actions.shape[1], self.dynamics_model.phi_dim, batch_size])
-        V_x_prime_batch = torch.zeros([self.all_actions.shape[1], batch_size])
-        for action_index in range(K_us.shape[0]):
-            phi_x_prime_hat_batch = K_us[action_index] @ phi_x_batch  # (dim_phi, batch_size)
-            # x_prime_hat_batch = self.dynamics_model.B.T @ phi_x_prime_hat_batch # (X.shape[0], batch_size)
-            phi_x_prime_batch[action_index] = phi_x_prime_hat_batch
-            # phi_x_prime_batch[action_index] = self.dynamics_model.phi(x_primes_hat) # (dim_phi, batch_size)
-            V_x_prime_batch[action_index] = self.V_phi_x(phi_x_prime_batch[action_index])  # (1, batch_size)
+        # Compute phi(x') for all ( phi(x), action ) pairs and compute V(x')s (vectorized)
+        K_us = self.dynamics_model.K_(self.all_actions)  # (num_actions, phi_dim, phi_dim)
+        phi_x_prime_batch = torch.einsum("aij,jb->aib", K_us, phi_x_batch)  # (num_actions, phi_dim, batch)
+        w = self.value_function_weights.squeeze(-1)  # (phi_dim,)
+        V_x_prime_batch = torch.einsum("p,apb->ab", w, phi_x_prime_batch)  # (num_actions, batch)
 
         # Compute policy distribution
         inner_pi_us_values = -(costs + self.discount_factor * V_x_prime_batch)  # (all_actions.shape[1], batch_size)
@@ -678,11 +355,15 @@ class DiscreteKoopmanValueIterationPolicy:
         pis_response = self.pis(x)[:, 0]
 
         if is_greedy:
-            selected_indices = torch.ones(sample_size, dtype=torch.int8) * torch.argmax(pis_response)
+            selected_indices = torch.ones(
+                sample_size, dtype=torch.int8, device=self.device
+            ) * torch.argmax(pis_response)
         else:
             selected_indices = torch.from_numpy(
-                np.random.choice(np.arange(len(pis_response)), size=sample_size, p=pis_response)
-            )
+                np.random.choice(
+                    np.arange(len(pis_response)), size=sample_size, p=pis_response.detach().cpu().numpy()
+                )
+            ).to(self.device)
 
         return (
             self.all_actions[0][selected_indices.long()],
@@ -765,7 +446,7 @@ class DiscreteKoopmanValueIterationPolicy:
         self.discount_factor = self.gamma**self.dt
 
         # Compute initial Bellman error
-        BE = self.discrete_bellman_error(batch_size=batch_size * batch_scale).detach().numpy()
+        BE = self.discrete_bellman_error(batch_size=batch_size * batch_scale).detach().cpu().numpy()
         bellman_errors = [BE]
         print(f"Initial Bellman error: {BE}")
 
@@ -779,21 +460,18 @@ class DiscreteKoopmanValueIterationPolicy:
                 # Get random batch of X and Phi_X from tensor training data
                 x_batch_indices = torch.from_numpy(
                     np.random.choice(self.dynamics_model.X.shape[1], batch_size, replace=False)
-                )
+                ).to(self.device)
                 x_batch = self.dynamics_model.X[:, x_batch_indices.long()]  # (X.shape[0], batch_size)
                 phi_x_batch = self.dynamics_model.Phi_X[:, x_batch_indices.long()]  # (dim_phi, batch_size)
 
                 # Compute costs indexed by the action and the state
-                costs = torch.Tensor(self.cost(x_batch.T, self.all_actions.T))  # (all_actions.shape[1], batch_size)
+                costs = self.cost(x_batch.T, self.all_actions.T)  # (num_actions, batch)
 
-                # Compute V(x')s
-                K_us = self.dynamics_model.K_(self.all_actions)  # (all_actions.shape[1], phi_dim, phi_dim)
-                phi_x_prime_batch = torch.zeros((self.all_actions.shape[1], self.dynamics_model.phi_dim, batch_size))
-                V_x_prime_batch = torch.zeros((self.all_actions.shape[1], batch_size))
-                for action_index in range(phi_x_prime_batch.shape[0]):
-                    phi_x_prime_hat_batch = K_us[action_index] @ phi_x_batch  # (phi_dim, batch_size)
-                    phi_x_prime_batch[action_index] = phi_x_prime_hat_batch
-                    V_x_prime_batch[action_index] = self.V_phi_x(phi_x_prime_batch[action_index])  # (1, batch_size)
+                # Compute V(x')s (vectorized)
+                K_us = self.dynamics_model.K_(self.all_actions)  # (num_actions, phi_dim, phi_dim)
+                phi_x_prime_batch = torch.einsum("aij,jb->aib", K_us, phi_x_batch)  # (num_actions, phi_dim, batch)
+                w = self.value_function_weights.squeeze(-1)  # (phi_dim,)
+                V_x_prime_batch = torch.einsum("p,apb->ab", w, phi_x_prime_batch)  # (num_actions, batch)
 
                 # Compute policy distribution
                 inner_pi_us_values = -(
@@ -834,7 +512,7 @@ class DiscreteKoopmanValueIterationPolicy:
                     self.value_function_optimizer.step()
 
                 # Recompute Bellman error
-                BE = self.discrete_bellman_error(batch_size=batch_size * batch_scale).detach().numpy()
+                BE = self.discrete_bellman_error(batch_size=batch_size * batch_scale).detach().cpu().numpy()
                 bellman_errors.append(BE)
 
                 # Print epoch number
@@ -888,8 +566,9 @@ def main():
         "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
     )
 
-    # CPU-only execution
-    device = torch.device("cpu")
+    # Resolve compute device and dtype from flags
+    device = resolve_device(args.cuda)
+    torch.set_default_dtype(resolve_dtype(args.fp32))
 
     # TRY NOT TO MODIFY: seeding
     random.seed(args.seed)
@@ -908,6 +587,8 @@ def main():
         state_order=args.state_order,
         action_order=args.action_order,
         regressor=args.regressor,
+        device=device,
+        dtype=resolve_dtype(args.fp32),
     )
 
     try:
@@ -922,7 +603,7 @@ def main():
             stop=envs.single_action_space.high,
             num=args.num_actions,
         )
-    ).T
+    ).T.to(device)
 
     # Construct value iteration policy
     value_iteration_policy = DiscreteKoopmanValueIterationPolicy(
@@ -936,6 +617,7 @@ def main():
         learning_rate=args.lr,
         seed=args.seed,
         dt=dt,
+        device=device,
     )
 
     # Use Koopman tensor training data to train policy

--- a/koopmanrl/soft_koopman_value_iteration.py
+++ b/koopmanrl/soft_koopman_value_iteration.py
@@ -11,7 +11,10 @@ from torch.utils.tensorboard import SummaryWriter
 
 from koopmanrl.environments import DoubleWell, FluidFlow, LinearSystem, Lorenz
 from koopmanrl.koopman_observables import monomials
-from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor, generate_koopman_tensor
+from koopmanrl.koopman_tensor.torch_tensor import (
+    KoopmanTensor,
+    generate_koopman_tensor,
+)
 from koopmanrl.utils import (
     create_folder,
     load_and_apply_config,
@@ -355,14 +358,12 @@ class DiscreteKoopmanValueIterationPolicy:
         pis_response = self.pis(x)[:, 0]
 
         if is_greedy:
-            selected_indices = torch.ones(
-                sample_size, dtype=torch.int8, device=self.device
-            ) * torch.argmax(pis_response)
+            selected_indices = torch.ones(sample_size, dtype=torch.int8, device=self.device) * torch.argmax(
+                pis_response
+            )
         else:
             selected_indices = torch.from_numpy(
-                np.random.choice(
-                    np.arange(len(pis_response)), size=sample_size, p=pis_response.detach().cpu().numpy()
-                )
+                np.random.choice(np.arange(len(pis_response)), size=sample_size, p=pis_response.detach().cpu().numpy())
             ).to(self.device)
 
         return (

--- a/koopmanrl/utils.py
+++ b/koopmanrl/utils.py
@@ -3,6 +3,17 @@ import os
 from typing import Any
 
 import gymnasium as gym
+import torch
+
+
+def resolve_device(cuda: bool) -> torch.device:
+    """Return the CUDA device when requested and available, else CPU."""
+    return torch.device("cuda" if (cuda and torch.cuda.is_available()) else "cpu")
+
+
+def resolve_dtype(fp32: bool) -> torch.dtype:
+    """FP64 by default; FP32 when opted in (faster on consumer Blackwell)."""
+    return torch.float32 if fp32 else torch.float64
 
 
 def load_and_apply_config(

--- a/koopmanrl/value_based_sac_continuous_action.py
+++ b/koopmanrl/value_based_sac_continuous_action.py
@@ -131,8 +131,7 @@ def main():
     torch.manual_seed(sampled_seed)
     torch.backends.cudnn.deterministic = args.torch_deterministic
 
-    # Running everything on CPU
-    device = torch.device("cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
     envs = gym.vector.SyncVectorEnv([make_env(args.env_id, sampled_seed, 0, args.capture_video, run_name)])
@@ -223,6 +222,15 @@ def main():
         if global_step > args.learning_starts:
             # Sample from replay buffer
             data = rb.sample(args.batch_size)
+            # SB3 ReplayBuffer always stores float32; cast to the network dtype (float64 by default).
+            net_dtype = next(actor.parameters()).dtype
+            data = data._replace(
+                observations=data.observations.to(dtype=net_dtype),
+                actions=data.actions.to(dtype=net_dtype),
+                next_observations=data.next_observations.to(dtype=net_dtype),
+                rewards=data.rewards.to(dtype=net_dtype),
+                dones=data.dones.to(dtype=net_dtype),
+            )
 
             # E_s_t~D [ 1/2 ( V_psi( s_t ) - E_a_t~pi_phi [ Q_theta( s_t, a_t ) - log pi_phi( a_t | s_t ) ] )^2 ]
             vf_values = vf(data.observations).view(-1)

--- a/tests/test_device_utils.py
+++ b/tests/test_device_utils.py
@@ -1,0 +1,16 @@
+import torch
+from koopmanrl.utils import resolve_device, resolve_dtype
+
+
+def test_resolve_device_cpu_when_cuda_false():
+    assert resolve_device(False) == torch.device("cpu")
+
+
+def test_resolve_device_cuda_when_requested_and_available():
+    expected = "cuda" if torch.cuda.is_available() else "cpu"
+    assert resolve_device(True).type == expected
+
+
+def test_resolve_dtype():
+    assert resolve_dtype(False) == torch.float64
+    assert resolve_dtype(True) == torch.float32

--- a/tests/test_device_utils.py
+++ b/tests/test_device_utils.py
@@ -1,4 +1,5 @@
 import torch
+
 from koopmanrl.utils import resolve_device, resolve_dtype
 
 

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -5,6 +5,7 @@ import numpy as np
 import koopmanrl.environments  # noqa: F401
 
 from koopmanrl.koopman_tensor.observables.torch_observables import monomials
+from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor, generate_koopman_tensor
 
 CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 ATOL = 1e-9
@@ -19,9 +20,6 @@ def test_monomials_cpu_gpu_parity():
     y_gpu = phi(x_gpu)
     assert y_gpu.is_cuda
     assert torch.allclose(y_cpu, y_gpu.cpu(), atol=ATOL)
-
-
-from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor
 
 
 def _make_tensor(device):
@@ -177,9 +175,6 @@ def test_double_well_diffusion_matches_numpy():
         noise=torch.tensor(noise),
     )
     assert torch.allclose(out, torch.tensor(ref), atol=1e-9)
-
-
-from koopmanrl.koopman_tensor.torch_tensor import generate_koopman_tensor
 
 
 @CUDA

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -177,3 +177,20 @@ def test_double_well_diffusion_matches_numpy():
         noise=torch.tensor(noise),
     )
     assert torch.allclose(out, torch.tensor(ref), atol=1e-9)
+
+
+from koopmanrl.koopman_tensor.torch_tensor import generate_koopman_tensor
+
+
+@CUDA
+def test_generate_koopman_tensor_batched_gpu():
+    kt = generate_koopman_tensor(
+        env_id="Lorenz-v0", seed=0, num_paths=16, num_steps_per_path=20,
+        state_order=2, action_order=2, regressor="ols",
+        device=torch.device("cuda"),
+    )
+    assert kt.K.is_cuda
+    assert kt.X.shape[1] == 16 * 20
+    x = torch.randn(3, 5, dtype=torch.float64, device="cuda")
+    u = torch.randn(1, 5, dtype=torch.float64, device="cuda")
+    assert kt.f(x, u).is_cuda

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -1,5 +1,8 @@
 import pytest
 import torch
+import gymnasium as gym
+import numpy as np
+import koopmanrl.environments  # noqa: F401
 
 from koopmanrl.koopman_tensor.observables.torch_observables import monomials
 
@@ -46,3 +49,37 @@ def test_koopman_tensor_cpu_gpu_parity():
     f_cpu = kt_cpu.f(x, u)
     f_gpu = kt_gpu.f(x.cuda(), u.cuda())
     assert torch.allclose(f_cpu, f_gpu.cpu(), atol=1e-6)
+
+
+def test_linear_system_f_batch_matches_numpy_cpu():
+    env = gym.make("LinearSystem-v0").unwrapped
+    rng = np.random.default_rng(0)
+    states = rng.uniform(-5, 5, size=(8, env.state_dim))
+    actions = rng.uniform(-5, 5, size=(8, env.action_dim))
+    ref = np.stack([env.f(states[i], actions[i]) for i in range(8)])
+    out = env.f_batch(
+        torch.tensor(states, dtype=torch.float64),
+        torch.tensor(actions, dtype=torch.float64),
+    )
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-9)
+
+
+@CUDA
+def test_linear_system_f_batch_cpu_gpu_parity():
+    env = gym.make("LinearSystem-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(8, env.action_dim, dtype=torch.float64)
+    out_cpu = env.f_batch(s, a)
+    out_gpu = env.f_batch(s.cuda(), a.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)
+
+
+@CUDA
+def test_linear_system_cost_cpu_gpu_parity():
+    env = gym.make("LinearSystem-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(3, env.action_dim, dtype=torch.float64)
+    c_cpu = env.vectorized_cost_fn(s, a)
+    c_gpu = env.vectorized_cost_fn(s.cuda(), a.cuda())
+    assert torch.allclose(c_cpu, c_gpu.cpu(), atol=1e-9)

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -16,3 +16,33 @@ def test_monomials_cpu_gpu_parity():
     y_gpu = phi(x_gpu)
     assert y_gpu.is_cuda
     assert torch.allclose(y_cpu, y_gpu.cpu(), atol=ATOL)
+
+
+from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor
+
+
+def _make_tensor(device):
+    # Generate the data on CPU first, then move to the target device, so the CPU and
+    # GPU tensors are trained on *identical* data. torch.randn uses different RNG
+    # streams on CPU vs CUDA even with the same seed, so generating per-device would
+    # train the two tensors on different data and defeat the parity comparison.
+    torch.manual_seed(0)
+    N, state_dim, action_dim = 500, 3, 1
+    X = torch.randn(state_dim, N, dtype=torch.float64).to(device)
+    Y = (X.cpu() + 0.01 * torch.randn(state_dim, N, dtype=torch.float64)).to(device)
+    U = torch.randn(action_dim, N, dtype=torch.float64).to(device)
+    return KoopmanTensor(X, Y, U, phi=monomials(2), psi=monomials(2), regressor=Regressor.OLS)
+
+
+@CUDA
+def test_koopman_tensor_cpu_gpu_parity():
+    kt_cpu = _make_tensor(torch.device("cpu"))
+    kt_gpu = _make_tensor(torch.device("cuda"))
+    assert kt_gpu.K.is_cuda and kt_gpu.B.is_cuda
+    assert torch.allclose(kt_cpu.K, kt_gpu.K.cpu(), atol=1e-6)
+    assert torch.allclose(kt_cpu.B, kt_gpu.B.cpu(), atol=1e-6)
+    x = torch.randn(3, 16, dtype=torch.float64)
+    u = torch.randn(1, 16, dtype=torch.float64)
+    f_cpu = kt_cpu.f(x, u)
+    f_gpu = kt_gpu.f(x.cuda(), u.cuda())
+    assert torch.allclose(f_cpu, f_gpu.cpu(), atol=1e-6)

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -83,3 +83,25 @@ def test_linear_system_cost_cpu_gpu_parity():
     c_cpu = env.vectorized_cost_fn(s, a)
     c_gpu = env.vectorized_cost_fn(s.cuda(), a.cuda())
     assert torch.allclose(c_cpu, c_gpu.cpu(), atol=1e-9)
+
+
+def test_fluid_flow_rk4_matches_scipy_accuracy():
+    env = gym.make("FluidFlow-v0").unwrapped
+    rng = np.random.default_rng(1)
+    states = rng.uniform(-1, 1, size=(8, env.state_dim))
+    actions = rng.uniform(-2, 2, size=(8, env.action_dim))
+    ref = np.stack([env.f(states[i], actions[i]) for i in range(8)])  # scipy RK45
+    out = env.f_batch(torch.tensor(states), torch.tensor(actions))
+    # Looser integrator-accuracy tolerance (RK4 substeps vs adaptive RK45)
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-4, rtol=1e-4)
+
+
+@CUDA
+def test_fluid_flow_f_batch_cpu_gpu_parity():
+    env = gym.make("FluidFlow-v0").unwrapped
+    s = torch.rand(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(8, env.action_dim, dtype=torch.float64)
+    out_cpu = env.f_batch(s, a)
+    out_gpu = env.f_batch(s.cuda(), a.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)  # same RK4 both sides -> tight

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -1,11 +1,15 @@
-import pytest
-import torch
 import gymnasium as gym
 import numpy as np
-import koopmanrl.environments  # noqa: F401
+import pytest
+import torch
 
+import koopmanrl.environments  # noqa: F401
 from koopmanrl.koopman_tensor.observables.torch_observables import monomials
-from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor, generate_koopman_tensor
+from koopmanrl.koopman_tensor.torch_tensor import (
+    KoopmanTensor,
+    Regressor,
+    generate_koopman_tensor,
+)
 
 CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 ATOL = 1e-9
@@ -133,10 +137,7 @@ def test_double_well_drift_matches_numpy():
     states = rng.uniform(-2, 2, size=(8, env.state_dim))
     actions = rng.uniform(-5, 5, size=(8, env.action_dim))
     # numpy drift-only reference (diffusion term zeroed)
-    ref = np.stack([
-        states[i] + env.continuous_f(actions[i])(0, states[i]) * env.dt
-        for i in range(8)
-    ])
+    ref = np.stack([states[i] + env.continuous_f(actions[i])(0, states[i]) * env.dt for i in range(8)])
     zero_noise = torch.zeros(8, env.state_dim, 1, dtype=torch.float64)
     out = env.f_batch(torch.tensor(states), torch.tensor(actions), noise=zero_noise)
     assert torch.allclose(out, torch.tensor(ref), atol=1e-9)
@@ -180,8 +181,13 @@ def test_double_well_diffusion_matches_numpy():
 @CUDA
 def test_generate_koopman_tensor_batched_gpu():
     kt = generate_koopman_tensor(
-        env_id="Lorenz-v0", seed=0, num_paths=16, num_steps_per_path=20,
-        state_order=2, action_order=2, regressor="ols",
+        env_id="Lorenz-v0",
+        seed=0,
+        num_paths=16,
+        num_steps_per_path=20,
+        state_order=2,
+        action_order=2,
+        regressor="ols",
         device=torch.device("cuda"),
     )
     assert kt.K.is_cuda

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -126,3 +126,31 @@ def test_lorenz_f_batch_cpu_gpu_parity():
     out_gpu = env.f_batch(s.cuda(), a.cuda())
     assert out_gpu.is_cuda
     assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)
+
+
+def test_double_well_drift_matches_numpy():
+    env = gym.make("DoubleWell-v0").unwrapped
+    env.reset(seed=0)
+    rng = np.random.default_rng(3)
+    states = rng.uniform(-2, 2, size=(8, env.state_dim))
+    actions = rng.uniform(-5, 5, size=(8, env.action_dim))
+    # numpy drift-only reference (diffusion term zeroed)
+    ref = np.stack([
+        states[i] + env.continuous_f(actions[i])(0, states[i]) * env.dt
+        for i in range(8)
+    ])
+    zero_noise = torch.zeros(8, env.state_dim, 1, dtype=torch.float64)
+    out = env.f_batch(torch.tensor(states), torch.tensor(actions), noise=zero_noise)
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-9)
+
+
+@CUDA
+def test_double_well_drift_cpu_gpu_parity():
+    env = gym.make("DoubleWell-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64)
+    a = torch.randn(8, env.action_dim, dtype=torch.float64)
+    zn = torch.zeros(8, env.state_dim, 1, dtype=torch.float64)
+    out_cpu = env.f_batch(s, a, noise=zn)
+    out_gpu = env.f_batch(s.cuda(), a.cuda(), noise=zn.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -105,3 +105,24 @@ def test_fluid_flow_f_batch_cpu_gpu_parity():
     out_gpu = env.f_batch(s.cuda(), a.cuda())
     assert out_gpu.is_cuda
     assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)  # same RK4 both sides -> tight
+
+
+def test_lorenz_rk4_matches_scipy_accuracy():
+    env = gym.make("Lorenz-v0").unwrapped
+    rng = np.random.default_rng(2)
+    states = rng.uniform(-10, 10, size=(8, env.state_dim))
+    actions = rng.uniform(-20, 20, size=(8, env.action_dim))
+    ref = np.stack([env.f(states[i], actions[i]) for i in range(8)])
+    out = env.f_batch(torch.tensor(states), torch.tensor(actions))
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-3, rtol=1e-3)
+
+
+@CUDA
+def test_lorenz_f_batch_cpu_gpu_parity():
+    env = gym.make("Lorenz-v0").unwrapped
+    s = torch.randn(8, env.state_dim, dtype=torch.float64) * 5
+    a = torch.randn(8, env.action_dim, dtype=torch.float64) * 5
+    out_cpu = env.f_batch(s, a)
+    out_gpu = env.f_batch(s.cuda(), a.cuda())
+    assert out_gpu.is_cuda
+    assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -1,0 +1,18 @@
+import pytest
+import torch
+
+from koopmanrl.koopman_tensor.observables.torch_observables import monomials
+
+CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ATOL = 1e-9
+
+
+@CUDA
+def test_monomials_cpu_gpu_parity():
+    phi = monomials(3)
+    x_cpu = torch.randn(3, 64, dtype=torch.float64)
+    x_gpu = x_cpu.cuda()
+    y_cpu = phi(x_cpu)
+    y_gpu = phi(x_gpu)
+    assert y_gpu.is_cuda
+    assert torch.allclose(y_cpu, y_gpu.cpu(), atol=ATOL)

--- a/tests/test_gpu_parity.py
+++ b/tests/test_gpu_parity.py
@@ -154,3 +154,26 @@ def test_double_well_drift_cpu_gpu_parity():
     out_gpu = env.f_batch(s.cuda(), a.cuda(), noise=zn.cuda())
     assert out_gpu.is_cuda
     assert torch.allclose(out_cpu, out_gpu.cpu(), atol=1e-9)
+
+
+def test_double_well_diffusion_matches_numpy():
+    """Validate the full f_batch (drift + diffusion) against the numpy formula with injected noise."""
+    env = gym.make("DoubleWell-v0").unwrapped
+    rng = np.random.default_rng(7)
+    states = rng.uniform(-2, 2, size=(8, env.state_dim))
+    actions = rng.uniform(-5, 5, size=(8, env.action_dim))
+    noise = rng.standard_normal(size=(8, env.state_dim, 1))
+    # numpy reference: state + drift*dt + (sigma_x @ noise * sqrt(dt))[:,0]
+    ref = []
+    for i in range(8):
+        drift = np.array(env.continuous_f(actions[i])(0, states[i])) * env.dt
+        sigma_x = np.array([[0.7, states[i, 0]], [0.0, 0.5]])
+        diffusion = (sigma_x @ noise[i] * np.sqrt(env.dt))[:, 0]
+        ref.append(states[i] + drift + diffusion)
+    ref = np.stack(ref)
+    out = env.f_batch(
+        torch.tensor(states),
+        torch.tensor(actions),
+        noise=torch.tensor(noise),
+    )
+    assert torch.allclose(out, torch.tensor(ref), atol=1e-9)

--- a/tests/test_rl.py
+++ b/tests/test_rl.py
@@ -94,3 +94,22 @@ def test_sac_v_cuda(env_id):
         [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
     )
     assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+def test_skvi_fp32_cuda():
+    result = run_module(
+        "koopmanrl.soft_koopman_value_iteration",
+        [f"--env_id={ENVS[0]}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda", "--fp32"],
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+def test_sakc_fp32_cuda():
+    result = run_module(
+        "koopmanrl.soft_actor_koopman_critic",
+        [f"--env_id={ENVS[0]}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda", "--fp32", "--learning_starts=500"],
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_rl.py
+++ b/tests/test_rl.py
@@ -1,9 +1,12 @@
 import pytest
+import torch
 
 from tests.utils import run_module
 
 TOTAL_TIMESTEPS = 1000
 ENVS = ["LinearSystem-v0", "FluidFlow-v0", "Lorenz-v0", "DoubleWell-v0"]
+
+cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 
 
 @pytest.mark.parametrize("env_id", ENVS)
@@ -48,5 +51,46 @@ def test_sakc(env_id):
     result = run_module(
         "koopmanrl.soft_actor_koopman_critic",
         [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}"],
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_skvi_cuda(env_id):
+    result = run_module(
+        "koopmanrl.soft_koopman_value_iteration",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_sakc_cuda(env_id):
+    result = run_module(
+        "koopmanrl.soft_actor_koopman_critic",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda", "--learning_starts=500"],
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_sac_q_cuda(env_id):
+    result = run_module(
+        "koopmanrl.sac_continuous_action",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@cuda_only
+@pytest.mark.parametrize("env_id", ENVS)
+def test_sac_v_cuda(env_id):
+    result = run_module(
+        "koopmanrl.value_based_sac_continuous_action",
+        [f"--env_id={env_id}", f"--total_timesteps={TOTAL_TIMESTEPS}", "--cuda"],
     )
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Makes the 4 control environments **and** the RL algorithms run on an NVIDIA GPU (validated on RTX 5090 / Blackwell `sm_120`, `torch 2.9.1+cu128`), validated against the CPU baseline. `--cuda` is opt-in; default behavior is unchanged.

- **Hybrid environments** — keep the FP64/CPU Gymnasium single-env API as the parity reference, and add batched, device-native `f_batch`/`reset_batch` (substepped RK4 for FluidFlow/Lorenz, Euler–Maruyama for DoubleWell, linear algebra for LinearSystem) plus a device-aware `vectorized_cost_fn`.
- **Single canonical device-aware `KoopmanTensor`** (`koopman_tensor/torch_tensor.py`) — removed the `self.M.numpy()` round-trip and the Python `kron` loop (vectorized via einsum/transpose), made the monomial observables device-aware. SKVI/SAKC now import it instead of carrying inline copies (~690 lines of duplication removed).
- **Algorithms on GPU** — `--cuda` and `--fp32` wired through SKVI, SAKC, both CleanRL SAC variants, and both Optuna wrappers (the flag was previously parsed but ignored). SKVI's per-action Python loop is vectorized into einsums. **LQR stays on CPU by design** (classical Riccati solve).
- **Batched GPU data-gen** — `generate_koopman_tensor` runs all paths in parallel on-device, replacing sequential `scipy.solve_ivp` calls.
- **Validation** — new `tests/test_gpu_parity.py` (CPU↔GPU parity for env dynamics, cost, Koopman tensor, monomials, at machine precision) and CUDA smoke/training tests in `tests/test_rl.py`.
- **Latent bugs fixed along the way** — SB3 ReplayBuffer float32↔float64 mismatch (SAKC/SAC training never actually ran in old tests), `Actor` buffers now follow the default dtype (so `--fp32` works), and `generate_tensor.py`'s missing env-registration import.

Design and plan: `docs/superpowers/specs/2026-05-22-gpu-koopmanrl-design.md`, `docs/superpowers/plans/2026-05-22-gpu-koopmanrl.md`.

## Test plan

- [ ] CPU baseline preserved: `uv run pytest tests/test_environments.py tests/test_rl.py -k "not cuda"` → 28 passed
- [ ] Full GPU suite on a CUDA box: `uv run pytest tests/test_device_utils.py tests/test_environments.py tests/test_gpu_parity.py tests/test_rl.py` → 62 passed (RTX 5090)
- [ ] `uv run pre-commit run --all-files` → clean

> Note: `tests/test_hparam_opt.py` (8 tests) fails on `master` too — a pre-existing hardcoded absolute `storage_dir` in the Optuna scripts, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)