### PR TITLE
feat: stable solve-based Ridge regression backend

### DIFF
--- a/koopmanrl/koopman_tensor/torch_tensor.py
+++ b/koopmanrl/koopman_tensor/torch_tensor.py
@@ -138,8 +138,9 @@ class KoopmanTensor:
             Dictionary space representing the actions.
         regressor : {'ols', 'sindy', 'rrr'}, optional
             String indicating the regression method to use. Default is 'ols'.
-        p_inv : bool, optional
-            Boolean indicating whether to use pseudo-inverse instead of regular inverse. Default is True.
+        regressor_kwargs : dict, optional
+            Extra keyword arguments forwarded to the selected regressor (e.g. ``alpha`` for
+            ridge). Default is None (treated as an empty dict).
         rank : int, optional
             Rank of the Koopman tensor when applying reduced rank regression. Default is 8.
         is_generator : bool, optional
@@ -315,6 +316,7 @@ def generate_koopman_tensor(
     state_order,
     action_order,
     regressor,
+    regressor_kwargs=None,
     device=None,
     dtype=torch.float64,
 ):
@@ -341,6 +343,8 @@ def generate_koopman_tensor(
         Monomial order for the action observable psi.
     regressor : str
         Regression method: one of "ols", "sindy", "rrr", "ridge".
+    regressor_kwargs : dict, optional
+        Extra keyword arguments forwarded to the selected regressor (e.g. ``alpha`` for ridge).
     device : torch.device or None
         Target device.  Defaults to CPU.
     dtype : torch.dtype
@@ -397,7 +401,12 @@ def generate_koopman_tensor(
         Y = Y.reshape(n, state_dim).T.to(device)
         U = U.reshape(n, action_dim).T.to(device)
 
-    kwargs = dict(phi=monomials(state_order), psi=monomials(action_order), regressor=Regressor(regressor))
+    kwargs = dict(
+        phi=monomials(state_order),
+        psi=monomials(action_order),
+        regressor=Regressor(regressor),
+        regressor_kwargs=regressor_kwargs,
+    )
     try:
         return KoopmanTensor(X, Y, U, dt=base.dt, **kwargs)
     except AttributeError:

--- a/koopmanrl/koopman_tensor/torch_tensor.py
+++ b/koopmanrl/koopman_tensor/torch_tensor.py
@@ -118,7 +118,9 @@ class Regressor(str, Enum):
 
 
 class KoopmanTensor:
-    def __init__(self, X, Y, U, phi, psi, regressor=Regressor.OLS, rank=8, is_generator=False, dt=0.01):
+    def __init__(
+        self, X, Y, U, phi, psi, regressor=Regressor.OLS, rank=8, is_generator=False, dt=0.01, regressor_kwargs=None
+    ):
         """
         Create an instance of the KoopmanTensor class.
 
@@ -150,6 +152,7 @@ class KoopmanTensor:
         KoopmanTensor
             An instance of the KoopmanTensor class.
         """
+        regressor_kwargs = regressor_kwargs or {}
 
         # Save datasets
         self.X = X
@@ -225,8 +228,8 @@ class KoopmanTensor:
             self.M = ols(self.kron_matrix.T, self.regression_Y.T).T
             self.B = ols(self.Phi_X.T, self.X.T)
         elif regressor == Regressor.RIDGE:
-            self.M = ridgeRegression(self.kron_matrix.T, self.regression_Y.T).T
-            self.B = ridgeRegression(self.Phi_X.T, self.X.T)
+            self.M = ridge(self.kron_matrix.T, self.regression_Y.T, **regressor_kwargs).T
+            self.B = ridge(self.Phi_X.T, self.X.T, **regressor_kwargs)
         else:
             raise Exception("Did not pick a supported regression algorithm.")
 

--- a/koopmanrl/koopman_tensor/torch_tensor.py
+++ b/koopmanrl/koopman_tensor/torch_tensor.py
@@ -71,9 +71,37 @@ def RRR(X, Y, rank=8):
     return rrr(X, Y, rank)
 
 
-def ridgeRegression(X, y, lamb=0.05):
+def ridge(X, Y, alpha=0.05):
+    """
+    Ridge regression via the normal equations, solved without forming an
+    explicit inverse (numerically stable on ill-conditioned feature matrices).
+
+    Solves ``(X^T X + alpha I) Xi = X^T Y`` for ``Xi``.
+
+    Parameters
+    ----------
+    X : (n_samples, n_features) tensor
+    Y : (n_samples, n_targets) tensor
+        Regression targets (a 1-D target is treated as a single column).
+    alpha : float
+        L2 regularization strength (``alpha=0`` -> OLS).
+
+    Returns
+    -------
+    Xi : (n_features, n_targets) tensor
+        Coefficient matrix on ``X``'s device/dtype.
+    """
+    if Y.ndim == 1:
+        Y = Y.unsqueeze(1)
+    if alpha == 0.0:
+        return torch.linalg.lstsq(X, Y, rcond=None).solution
     eye = torch.eye(X.shape[1], device=X.device, dtype=X.dtype)
-    return torch.linalg.inv(X.T @ X + lamb * eye) @ X.T @ y
+    return torch.linalg.solve(X.T @ X + alpha * eye, X.T @ Y)
+
+
+# Backwards-compatible alias.
+def ridgeRegression(X, Y, alpha=0.05):
+    return ridge(X, Y, alpha=alpha)
 
 
 """ Regressor enum """

--- a/tests/test_regression_ridge.py
+++ b/tests/test_regression_ridge.py
@@ -87,7 +87,12 @@ def test_koopman_tensor_ridge_accepts_alpha_kwarg():
 
     X, Y, U, _ = _build_dataset()
     kt = KoopmanTensor(
-        X, Y, U, phi=monomials(2), psi=monomials(2),
-        regressor=Regressor.RIDGE, regressor_kwargs={"alpha": 1.0},
+        X,
+        Y,
+        U,
+        phi=monomials(2),
+        psi=monomials(2),
+        regressor=Regressor.RIDGE,
+        regressor_kwargs={"alpha": 1.0},
     )
     assert kt.K is not None

--- a/tests/test_regression_ridge.py
+++ b/tests/test_regression_ridge.py
@@ -1,0 +1,93 @@
+import torch
+
+from koopmanrl.koopman_tensor.torch_tensor import ridge
+
+
+def test_ridge_matches_closed_form():
+    """Matches the explicit-inverse closed form on a well-conditioned problem."""
+    g = torch.Generator().manual_seed(0)
+    X = torch.randn(80, 5, generator=g)
+    Y = torch.randn(80, 3, generator=g)
+    alpha = 0.5
+    eye = torch.eye(5)
+    ref = torch.linalg.inv(X.T @ X + alpha * eye) @ X.T @ Y
+    assert torch.allclose(ridge(X, Y, alpha=alpha), ref, atol=1e-8)
+
+
+def test_ridge_alpha_zero_reduces_to_ols():
+    g = torch.Generator().manual_seed(1)
+    X = torch.randn(80, 5, generator=g)
+    Y = torch.randn(80, 3, generator=g)
+    ols_sol = torch.linalg.lstsq(X, Y, rcond=None).solution
+    assert torch.allclose(ridge(X, Y, alpha=0.0), ols_sol, atol=1e-8)
+
+
+def test_ridge_shrinks_coefficients_with_alpha():
+    g = torch.Generator().manual_seed(2)
+    X = torch.randn(80, 5, generator=g)
+    Y = torch.randn(80, 3, generator=g)
+    small = torch.linalg.norm(ridge(X, Y, alpha=0.01))
+    large = torch.linalg.norm(ridge(X, Y, alpha=100.0))
+    assert large < small
+
+
+def test_ridge_is_stable_on_ill_conditioned_features():
+    """Near-collinear columns: ridge stays finite where naive inverse degrades."""
+    g = torch.Generator().manual_seed(3)
+    base = torch.randn(100, 1, generator=g)
+    X = torch.cat([base, base + 1e-9 * torch.randn(100, 1, generator=g), torch.randn(100, 2, generator=g)], dim=1)
+    Y = torch.randn(100, 2, generator=g)
+    Xi = ridge(X, Y, alpha=1.0)
+    assert Xi.shape == (4, 2)
+    assert torch.isfinite(Xi).all()
+
+
+def test_ridge_contract_shape_and_dtype():
+    X = torch.randn(30, 4)
+    Y = torch.randn(30, 2)
+    Xi = ridge(X, Y)
+    assert Xi.shape == (4, 2)
+    assert Xi.dtype == X.dtype
+
+
+def test_ridge_handles_1d_target():
+    X = torch.randn(40, 3)
+    y = torch.randn(40)
+    Xi = ridge(X, y, alpha=0.1)
+    assert Xi.shape == (3, 1)
+
+
+def _build_dataset():
+    g = torch.Generator().manual_seed(0)
+    n, state_dim, action_dim = 300, 2, 1
+    X = torch.randn(state_dim, n, generator=g)
+    A = torch.tensor([[0.9, 0.1], [-0.2, 0.8]])
+    Y = A @ X
+    U = torch.randn(action_dim, n, generator=g)
+    return X, Y, U, state_dim
+
+
+def test_koopman_tensor_ridge_end_to_end():
+    from koopmanrl.koopman_tensor.observables.torch_observables import monomials
+    from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor
+
+    X, Y, U, state_dim = _build_dataset()
+    kt = KoopmanTensor(X, Y, U, phi=monomials(2), psi=monomials(2), regressor=Regressor.RIDGE)
+    assert kt.K.shape == (kt.phi_dim, kt.phi_dim, kt.psi_dim)
+    x = torch.randn(state_dim, 8)
+    u = torch.randn(1, 8)
+    pred = kt.f(x, u)
+    assert pred.shape == (state_dim, 8)
+    assert torch.isfinite(pred).all()
+
+
+def test_koopman_tensor_ridge_accepts_alpha_kwarg():
+    from koopmanrl.koopman_tensor.observables.torch_observables import monomials
+    from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor
+
+    X, Y, U, _ = _build_dataset()
+    kt = KoopmanTensor(
+        X, Y, U, phi=monomials(2), psi=monomials(2),
+        regressor=Regressor.RIDGE, regressor_kwargs={"alpha": 1.0},
+    )
+    assert kt.K is not None

--- a/tests/test_regression_ridge.py
+++ b/tests/test_regression_ridge.py
@@ -32,7 +32,8 @@ def test_ridge_shrinks_coefficients_with_alpha():
 
 
 def test_ridge_is_stable_on_ill_conditioned_features():
-    """Near-collinear columns: ridge stays finite where naive inverse degrades."""
+    """Near-collinear columns: ridge returns a finite, well-bounded solution (regularization
+    keeps coefficients from blowing up on near-singular input)."""
     g = torch.Generator().manual_seed(3)
     base = torch.randn(100, 1, generator=g)
     X = torch.cat([base, base + 1e-9 * torch.randn(100, 1, generator=g), torch.randn(100, 2, generator=g)], dim=1)
@@ -40,6 +41,7 @@ def test_ridge_is_stable_on_ill_conditioned_features():
     Xi = ridge(X, Y, alpha=1.0)
     assert Xi.shape == (4, 2)
     assert torch.isfinite(Xi).all()
+    assert torch.linalg.norm(Xi) < 1e3  # regularized solution stays bounded
 
 
 def test_ridge_contract_shape_and_dtype():
@@ -86,13 +88,25 @@ def test_koopman_tensor_ridge_accepts_alpha_kwarg():
     from koopmanrl.koopman_tensor.torch_tensor import KoopmanTensor, Regressor
 
     X, Y, U, _ = _build_dataset()
-    kt = KoopmanTensor(
-        X,
-        Y,
-        U,
-        phi=monomials(2),
-        psi=monomials(2),
-        regressor=Regressor.RIDGE,
+    common = dict(phi=monomials(2), psi=monomials(2), regressor=Regressor.RIDGE)
+    kt_default = KoopmanTensor(X, Y, U, **common)
+    kt_strong = KoopmanTensor(X, Y, U, regressor_kwargs={"alpha": 100.0}, **common)
+    assert kt_strong.K is not None
+    # A large alpha must measurably change the learned operator.
+    assert not torch.allclose(kt_default.M, kt_strong.M)
+
+
+def test_generate_koopman_tensor_threads_regressor_kwargs():
+    from koopmanrl.koopman_tensor.torch_tensor import generate_koopman_tensor
+
+    kt = generate_koopman_tensor(
+        env_id="LinearSystem-v0",
+        seed=0,
+        num_paths=10,
+        num_steps_per_path=20,
+        state_order=2,
+        action_order=2,
+        regressor="ridge",
         regressor_kwargs={"alpha": 1.0},
     )
     assert kt.K is not None


### PR DESCRIPTION
## Summary
- Reimplements Ridge regression via the normal equations using `torch.linalg.solve` (no explicit inverse) — numerically stable on ill-conditioned feature matrices; `alpha=0` reduces to OLS; device/dtype preserved.
- Threads a `regressor_kwargs` argument through `KoopmanTensor` so `alpha` is configurable.
- Adds `tests/test_regression_ridge.py`: closed-form correctness, alpha→OLS reduction, shrinkage monotonicity, ill-conditioned stability, contract/dtype, 1-D target, plus end-to-end `KoopmanTensor` tests.

## Verification
- `uv run pytest tests/test_regression_ridge.py` — green.
- `uv run pytest tests/test_rl.py tests/test_environments.py` — green.
- `uv run pre-commit run --all-files` — green.

Design spec: `docs/superpowers/specs/2026-05-25-regression-backends-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)